### PR TITLE
 Fix block deletion reliability and yank rich text formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Vimtion will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3] - 2026-04-13
+
+### Fixed
+- **Block deletion reliability**: Improved mouse drag coordinates for block selection, increasing horizontal offset and using block edges for vertical coordinates to more reliably hit Notion's gutter area
+- **Yank preserves rich text formatting** ([#7](https://github.com/tatsukamijo/vimtion/issues/7)): `yy` and visual-line yank now use `execCommand("copy")` with DOM selection instead of `navigator.clipboard.writeText()`, preserving headings, lists, links, and inline formatting when pasting with Cmd+V
+- **Paste preserves rich text**: `p` now dispatches `ClipboardEvent` with HTML clipboard data so Notion processes formatting correctly
+
 ## [1.5.2] - 2026-01-17
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vimtion",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vimtion",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "ISC",
       "devDependencies": {
         "@parcel/transformer-typescript-tsc": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimtion",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A Chrome extension that brings Vim keybindings to Notion, updated for modern Chrome compatibility.",
   "scripts": {
     "build": "rm -rf dist && parcel build src/background.ts --dist-dir dist && parcel build src/content_scripts/{vim.ts,vim.css,update-notification.ts,update-notification.css} --dist-dir dist/content_scripts && parcel build src/options/{options.html,options.ts,options.css} --dist-dir dist/options --public-url ./ && cp src/manifest.json dist/ && cp -r src/icons dist/",

--- a/src/content_scripts/core/dom-utils.ts
+++ b/src/content_scripts/core/dom-utils.ts
@@ -57,10 +57,10 @@ export const deleteMultipleLinesAtomically = (
     const firstRect = firstBlock.getBoundingClientRect();
     const lastRect = lastBlock.getBoundingClientRect();
 
-    const startX = firstRect.left - 10;
-    const startY = firstRect.top + firstRect.height / 2;
+    const startX = firstRect.left - 30;
+    const startY = firstRect.top + 2;
     const endX = firstRect.left + 200;
-    const endY = lastRect.top + lastRect.height / 2;
+    const endY = lastRect.bottom - 2;
 
     const startElement = document.elementFromPoint(startX, startY);
 

--- a/src/content_scripts/operators/motion-yank.ts
+++ b/src/content_scripts/operators/motion-yank.ts
@@ -9,17 +9,18 @@ import { isParagraphBoundary } from "../notion";
 /**
  * Yank current line
  */
-export const createYankCurrentLine = () => async () => {
+export const createYankCurrentLine = () => () => {
   const { vim_info } = window;
   const currentElement = vim_info.lines[vim_info.active_line].element;
-  const text = currentElement.textContent || "";
 
-  try {
-    // Add newline to indicate line-wise yank (Vim behavior)
-    await navigator.clipboard.writeText(text + "\n");
-  } catch (err) {
-    console.error("[Vim-Notion] Failed to yank:", err);
-  }
+  const range = document.createRange();
+  range.selectNodeContents(currentElement);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+  document.execCommand("copy");
+  sel?.removeAllRanges();
+  vim_info.yank_type = "line";
 };
 
 /**

--- a/src/content_scripts/operators/yank.ts
+++ b/src/content_scripts/operators/yank.ts
@@ -86,16 +86,17 @@ export const yankAroundParagraph = async (
  * Yank current line
  * Used by: yy command
  */
-export const yankCurrentLine = async () => {
+export const yankCurrentLine = () => {
   const { vim_info } = window;
   const currentElement = vim_info.lines[vim_info.active_line].element;
-  const text = currentElement.textContent || "";
 
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (err) {
-    console.error("[Vim-Notion] Failed to yank:", err);
-  }
+  const range = document.createRange();
+  range.selectNodeContents(currentElement);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+  document.execCommand("copy");
+  sel?.removeAllRanges();
 };
 
 /**

--- a/src/content_scripts/state.ts
+++ b/src/content_scripts/state.ts
@@ -70,6 +70,7 @@ export function initVimInfo(): VimInfo {
     visual_start_line: 0,
     visual_start_pos: 0,
     pending_operator: null,
+    yank_type: null,
     undo_count: 0,
     in_undo_group: false,
     link_hints: [],

--- a/src/content_scripts/vim.ts
+++ b/src/content_scripts/vim.ts
@@ -1577,62 +1577,61 @@ const changeVisualLineSelection = () => {
 
 // yankVisualSelection and yankVisualLineSelection now created via factory below (after updateInfoContainer is defined)
 
+const dispatchPasteEvent = (
+  element: HTMLElement,
+  html: string,
+  text: string,
+) => {
+  const dt = new DataTransfer();
+  dt.setData("text/html", html);
+  dt.setData("text/plain", text);
+  const pasteEvent = new ClipboardEvent("paste", {
+    clipboardData: dt,
+    bubbles: true,
+    cancelable: true,
+  });
+  element.dispatchEvent(pasteEvent);
+};
+
 const pasteAfterCursor = async () => {
   const { vim_info } = window;
   const currentElement = vim_info.lines[vim_info.active_line].element;
   const currentCursorPosition = getCursorIndexInElement(currentElement);
 
   try {
-    const clipboardText = await navigator.clipboard.readText();
+    const items = await navigator.clipboard.read();
+    let html = "";
+    let text = "";
+    for (const item of items) {
+      if (item.types.includes("text/html")) {
+        html = await (await item.getType("text/html")).text();
+      }
+      if (item.types.includes("text/plain")) {
+        text = await (await item.getType("text/plain")).text();
+      }
+    }
 
-    // Check if clipboard contains a line (ends with newline)
-    const isLinePaste = clipboardText.endsWith("\n");
+    const isLinePaste = vim_info.yank_type === "line";
 
     if (isLinePaste) {
-      // Line paste: create new line below current line
-      // Remove the trailing newline from clipboard text
-      const textWithoutNewline = clipboardText.slice(0, -1);
-
-      // Move to end of current line
       const lineLength = currentElement.textContent?.length || 0;
       setCursorPosition(currentElement, lineLength);
+      currentElement.focus({ preventScroll: true });
 
-      // Switch to insert mode temporarily
       vim_info.mode = "insert";
+      dispatchPasteEvent(currentElement, "\n" + html, "\n" + text);
 
-      // Simulate Enter to create new line
       setTimeout(() => {
-        const enterEvent = new KeyboardEvent("keydown", {
-          key: "Enter",
-          code: "Enter",
-          keyCode: 13,
-          which: 13,
-          bubbles: true,
-          cancelable: true,
-        });
-        currentElement.dispatchEvent(enterEvent);
-
-        // Wait for new line to be created
-        setTimeout(() => {
-          refreshLines();
-
-          // Insert the text into the new line
-          const newLineIndex = vim_info.active_line + 1;
-          if (newLineIndex < vim_info.lines.length) {
-            const newLineElement = vim_info.lines[newLineIndex].element;
-            newLineElement.textContent = textWithoutNewline;
-            setCursorPosition(newLineElement, 0);
-            vim_info.active_line = newLineIndex;
-            vim_info.desired_column = 0;
-          }
-
-          // Return to normal mode
-          vim_info.mode = "normal";
-          updateInfoContainer();
-        }, 100);
-      }, 0);
+        vim_info.mode = "normal";
+        refreshLines();
+        const newLineIndex = Math.min(
+          vim_info.active_line + 1,
+          vim_info.lines.length - 1,
+        );
+        setActiveLine(newLineIndex);
+        updateInfoContainer();
+      }, 100);
     } else {
-      // Character paste: insert at cursor position
       const lineLength = currentElement.textContent?.length || 0;
       let pastePosition = currentCursorPosition;
       if (currentCursorPosition < lineLength) {
@@ -1640,18 +1639,15 @@ const pasteAfterCursor = async () => {
       }
 
       setCursorPosition(currentElement, pastePosition);
+      currentElement.focus({ preventScroll: true });
 
-      const text = currentElement.textContent || "";
-      const newText =
-        text.slice(0, pastePosition) +
-        clipboardText +
-        text.slice(pastePosition);
-      currentElement.textContent = newText;
+      vim_info.mode = "insert";
+      dispatchPasteEvent(currentElement, html || text, text);
 
-      // Move cursor to end of pasted text
-      const newCursorPosition = pastePosition + clipboardText.length - 1;
-      setCursorPosition(currentElement, newCursorPosition);
-      vim_info.desired_column = newCursorPosition;
+      setTimeout(() => {
+        vim_info.mode = "normal";
+        updateInfoContainer();
+      }, 100);
     }
   } catch (err) {
     console.error("[Vim-Notion] Failed to paste:", err);

--- a/src/content_scripts/visual/helpers.ts
+++ b/src/content_scripts/visual/helpers.ts
@@ -565,24 +565,11 @@ export const createYankVisualSelection = (updateInfoContainer: () => void) => {
 export const createYankVisualLineSelection = (
   updateInfoContainer: () => void,
 ) => {
-  return async () => {
+  return () => {
     const { vim_info } = window;
 
-    // Get the selected text from the browser selection
-    const selection = window.getSelection();
-    const selectedText = selection?.toString() || "";
+    document.execCommand("copy");
 
-    // Add newline to indicate line-wise yank (Vim behavior)
-    // This ensures paste (p) creates new lines instead of pasting inline
-    try {
-      await navigator.clipboard.writeText(selectedText + "\n");
-    } catch (err) {
-      console.error("[Vim-Notion] Failed to yank visual line selection:", err);
-      // Fallback to execCommand if clipboard API fails
-      document.execCommand("copy");
-    }
-
-    // Clear background highlights from all elements
     clearAllBackgroundColors();
 
     vim_info.mode = "normal";

--- a/src/content_scripts/window.d.ts
+++ b/src/content_scripts/window.d.ts
@@ -44,6 +44,7 @@ interface VimInfo {
     | "ct"
     | "cT"
     | null;
+  yank_type: "line" | "char" | null;
   undo_count: number;
   in_undo_group: boolean;
   link_hints: LinkHint[];

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vimtion: Vim for Notion",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A Chrome extension that brings Vim keybindings to Notion",
   "author": "Tatsuya Kamijo",
   "icons": {


### PR DESCRIPTION
## 🔄 Changes                                                                                                                                                                                                                    
- **Block deletion**: Adjusted mouse drag coordinates in `deleteMultipleLinesAtomically`: increased horizontal offset (`-10` → `-30`) and use block top/bottom edges instead of center for vertical coordinates, so single-block
 `dd` also has vertical drag distance                                                                                                                                                                                            
- **Yank preserves formatting** ([#7](https://github.com/tatsukamijo/vimtion/issues/7)): Replaced `navigator.clipboard.writeText()` with `execCommand("copy")` using DOM Range selection in `yy`, visual-line yank, and visual yank: clipboard now includes HTML so headings, lists, links, and inline styles are preserved                                                                                                                                    
- **Paste preserves formatting**: `p` now reads both `text/html` and `text/plain` from clipboard via `navigator.clipboard.read()` and dispatches a `ClipboardEvent` to let Notion handle rich content natively
                                                                                                                                                                                                                                 
## ⚠️ Breaking Changes                                    
- [ ] None                                                                                                                                                                                                                       
                                                          
## 🔍 How to Reproduce                                                                                                                                                                                                           
```bash
npm run build                                                                                                                                                                                                                    
# Load dist/ as unpacked extension in chrome://extensions/
```
- dd on various block types (text, bullets, headings) — verify deletion works reliably
- yy on a heading/bullet → Cmd+V in another location — verify formatting preserved    
- Vjjy → p — verify multi-line paste preserves formatting
- u after deletion — verify undo still works                                                                                                                                                                                     

