### PR TITLE
chore(ci): add PR and main branch lint and build checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,30 @@
+name: PR checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
# ci(pr-checks): add lint + build workflow on PR / main push

## 🔄 Changes                                                                                                                          
 
- Add `.github/workflows/pr-checks.yml` — runs `npm run lint` and `npm run build` on every PR targeting `main` and on direct pushes to 
`main`               
- Catches PRs that break the build or introduce ESLint violations before review reaches the human                                      
- Intentionally minimal: `tsc --noEmit` skipped (main has 6 pre-existing type errors that parcel still tolerates) and e2e skipped      
(needs Notion auth secret plumbing in a follow-up workflow)                                                                            
- Node 18, npm cache enabled, no other side effects                                                                                    
                                                                                                                                       
## ⚠️  Breaking Changes
- [ ] none — additive workflow only, doesn't touch source or existing release pipeline                                                 
                                                                                                                                       
## 🔍  How to Reproduce
```bash                                                                                                                                
# locally verify the same commands the workflow runs    
git checkout chore/ci-baseline                                                                                                         
npm ci                                                                                                                                 
npm run lint    # should pass with no output                                                                                           
npm run build   # should produce dist/ successfully                                                                                    
```                                                                                                                                    
                                                                       
## Notes                                                                                                                               
                                                        
This is the first of two CI PRs:                                                                                                       
1. **This PR** — lightweight gating (lint + build) for PRs to main
2. **Follow-up** — e2e CI requires Notion session-cookie management as a GitHub Secret + a periodic re-seeding workflow (Notion        
sessions expire). Tracked separately.                                                                                                  
                                                                                                                                       
Once merged, the in-flight `fix/cursor-state-drift` PR will get the new checks automatically. Existing `release.yml` (push to main +   
`package.json` change → Chrome Web Store upload) is untouched.         
                                                                                                                                       
### TODO:                                               
- [ ] follow-up PR: e2e CI workflow with Notion auth secret + smoke set on PR / nightly full run
- [ ] follow-up: clean up the 6 pre-existing tsc errors in `cursor/navigation-stack.ts`, `operators/motion-yank.ts`, `state.ts`,       
`vim.ts`, `window.d.ts` so we can add `tsc --noEmit` to the gate                                                                       
