### PR TITLE
fix(line-management): track post-undo cursor jumps in refreshLines

### DIFF
--- a/docs/known-bugs.md
+++ b/docs/known-bugs.md
@@ -32,6 +32,7 @@ Bugs detected during E2E test development. Kept separate from test refinement wo
 - **Reproduction**: Navigate to "Plain text line 3" (block index 4). Press o, type "new line via o", Escape. Then k. DOM cursor ends up on block 3 instead of block 4.
 - **Root cause**: `createRefreshLines` previously fell back to element-identity (and then `block_id`) recovery only. When `o` inserted a fresh leaf, the previously-active element was still in DOM (just at a new index), so identity recovery succeeded — but with the WRONG index relative to the user's intended position.
 - **Fix**: When the post-rebuild DOM Selection's leaf was NOT in the previous lines snapshot, prefer the selection's leaf as the new `active_line` source. Conservative predicate so rapid-navigation identity recovery (BUG-001 path) is not disturbed.
+- **Additional regression coverage**: `insert-open-line.spec.ts:370` (bullet) and `:393` (nested todo) markers were preserved through subsequent sprints and finally flipped to strict-pass during the BUG-040 sprint (commit `c0b111c` broadened the same selection-leaf recovery path used here, restoring stability for these BUG-003 fingerprints).
 - **Severity**: Was High — o is a frequently used Vim command.
 
 ## BUG-004: h at column 0 desyncs DOM selection
@@ -223,17 +224,20 @@ violation naming the exact shortcut that broke (`## conversion + Esc`,
 
 ## BUG-040: Post-undo cursor desync after o / O / A insert (broader than code blocks)
 
+- **Status**: **RESOLVED — PARTIAL**: 3 of 4 fingerprints fixed by `c0b111c`. Code-block-specific case (`o` inside code block + `u`) remains: Notion's undo moves DOM cursor to the heading above the code block while vim_info stays in code block — tier-1 broadening doesn't capture this. Test marker preserved at `code-block-nav.spec.ts:362`. Future work: needs code-block-specific reconciliation path.
 - **Detected**: 2026-05-03
+- **Resolved (partial)**: 2026-05-03
 - **Source**: Surfaced during BUG-011 fix work (see commit `6614210`); scope broadened during e07b3e5 verification.
 - **Reproduction patterns** (all fingerprint-identical):
-  - Inside a code block: `o` → type → `u`. DOM cursor lands on the heading above; `vim_info.active_line` still points at the code-block leaf.
-  - On a numbered/regular/nested bullet item: `A` → type → `Esc` → `j` → `u`. `vim_info.active_line` advances; DOM cursor stays one block back.
-  - On any insert variant: `o` → `Esc` (immediately, empty new line) → `u`. `vim_info.lines.length` (95) outpaces actual DOM editable count (94) — refreshLines missed the undo-driven leaf removal.
-  - On a nested bullet: `O` → `Esc` immediately → `u`. Same fingerprint.
-- **Root cause hypothesis**: `document.execCommand("undo")` rewinds Notion's DOM mutations (including leaf insertions/restorations), but our refreshLines/active_line reconciliation isn't triggered or doesn't follow the undo-driven changes — `vim_info` keeps the post-insert state while DOM rolls back.
-- **Verified pre-existing**: Reproduced on `0677b34` (parent of A/o `setCursorPastLineEnd` fix `2e5ee72`), so this is NOT a regression from any 2026-05-03 sprint commit.
-- **Tests `test.fail()`'d for this**: `insert-open-line.spec.ts:581` (A on numbered), `:691` (o + Esc empty), `:725` (O on nested bullet), `:362` (o in code block). Likely also `code-block-nav.spec.ts:424` and `:490` (same fingerprint, not yet marked).
-- **Severity**: Medium-High — broader than initially scoped; affects A/o/O across most block types after undo.
+  - Inside a code block: `o` → type → `u`. DOM cursor lands on the heading above; `vim_info.active_line` still points at the code-block leaf. **Still failing strict** (`code-block-nav.spec.ts:362`); marker preserved.
+  - On a numbered/regular/nested bullet item: `A` → type → `Esc` → `j` → `u`. `vim_info.active_line` advances; DOM cursor stays one block back. **Fixed** (`insert-open-line.spec.ts:586`).
+  - On any insert variant: `o` → `Esc` (immediately, empty new line) → `u`. `vim_info.lines.length` (95) outpaces actual DOM editable count (94) — refreshLines missed the undo-driven leaf removal. **Fixed** (`insert-open-line.spec.ts:702`).
+  - On a nested bullet: `O` → `Esc` immediately → `u`. Same fingerprint. **Fixed** (`insert-open-line.spec.ts:731`).
+- **Root cause**: `document.execCommand("undo")` rewinds Notion's DOM mutations (including leaf insertions/restorations), but the previous refreshLines/active_line reconciliation didn't follow undo-driven cursor jumps to pre-existing leaves — `vim_info` kept the post-insert state while DOM rolled back.
+- **Fix**: `c0b111c` broadens tier-1 (selection-leaf) recovery in `core/line-management.ts:createRefreshLines` to catch undo cursor-jumps to pre-existing leaves, and adds a characterData MutationObserver + `selectionchange` listener for the no-mutation cases. Three-tier recovery (selection-leaf / identity / block_id) preserved.
+- **Verified pre-existing**: Reproduced on `0677b34` (parent of A/o `setCursorPastLineEnd` fix `2e5ee72`), so this was NOT a regression from any 2026-05-03 sprint commit.
+- **Remaining work**: The code-block `o` + `u` fingerprint (`code-block-nav.spec.ts:362`) needs separate investigation — Notion's undo for code-block inserts moves DOM cursor to the heading above the code block, an interaction the current selection-leaf recovery doesn't capture. Marker stays until that case is addressed.
+- **Severity**: Was Medium-High — broader than initially scoped; affects A/o/O across most block types after undo. Three of four fingerprints now resolved.
 
 ## BUG-041: ``` markdown shortcut → code block conversion leaves cursor desynced
 

--- a/src/content_scripts/core/line-management.ts
+++ b/src/content_scripts/core/line-management.ts
@@ -5,6 +5,7 @@
 
 import { isInsideCodeBlock } from "../notion";
 import { setCursorPosition } from "../cursor";
+import { updateInfoContainer } from "../ui/info-container";
 
 /**
  * Event listener callbacks - to be provided by vim.ts
@@ -183,19 +184,32 @@ export const createRefreshLines = (handlers: EventHandlers) => {
         elem.closest("[data-block-id]")?.getAttribute("data-block-id") ?? null,
     }));
 
-    // Recover active line. Two signals:
-    //   - identity: previousActiveElement still in the rebuilt lines array
-    //   - selection: the DOM selection's leaf in the rebuilt lines array
-    // For ordinary navigation (rapid j/k) the cursor stays on
-    // previousActiveElement and the lines set is unchanged, so identity is
-    // correct. For mutations that insert a fresh leaf (o/O/Enter) the
-    // selection moves to that brand-new element. Identity recovery in that
-    // case finds the OLD element at its new index, which is no longer where
-    // the cursor actually is. Detect the o/O/Enter case narrowly: the
-    // selection sits on a leaf that did NOT exist in the previous lines
-    // snapshot. Using "freshly inserted" as the trigger keeps rapid
-    // navigation (no insertions) on the identity path, where Notion's
-    // transient leaf re-renders during click() can't shift active_line.
+    // Recover active line. Three tiers, in priority order:
+    //
+    //   1. Selection-leaf-as-truth: the DOM selection's leaf is in the
+    //      rebuilt array AND differs from previousActiveElement. This covers
+    //      both fresh-leaf insertion (o/O/Enter) and Notion-driven cursor
+    //      jumps to a *pre-existing* leaf (the dominant case is undo, which
+    //      can either roll back an insert — making previousActiveElement a
+    //      detached node — or refocus the block where the original edit
+    //      happened).
+    //
+    //   2. Element-identity: previousActiveElement still in the rebuilt
+    //      array. Covers ordinary navigation (rapid j/k) where the cursor
+    //      stayed on the active element and Notion's transient renderer
+    //      noise hasn't moved the selection.
+    //
+    //   3. block_id: previousActiveElement detached but its data-block-id
+    //      survives on a replacement node (markdown-shortcut swap territory,
+    //      e.g. paragraph→heading conversion).
+    //
+    // The (1) → (2) → (3) ordering matters. A previous narrow form of (1)
+    // gated on "selLeaf is brand new" to keep rapid j/k off this path, but
+    // that gate also blocked the post-undo cursor-jump cases where the new
+    // leaf is pre-existing. Tier 1 is now safe to broaden because rapid j/k
+    // ends with setCursorPosition leaving selLeaf === lines[active_line]
+    // .element === previousActiveElement, so the `selLeaf !==
+    // previousActiveElement` guard alone is enough to keep that path off.
     const selection = window.getSelection();
     const selAnchor = selection?.anchorNode ?? null;
     const selAnchorEl =
@@ -204,21 +218,18 @@ export const createRefreshLines = (handlers: EventHandlers) => {
         : selAnchor?.parentElement ?? null;
     const selLeaf = selAnchorEl?.closest('[contenteditable="true"]') ?? null;
 
-    if (
-      selLeaf &&
-      selLeaf !== previousActiveElement &&
-      !existingElements.has(selLeaf as HTMLDivElement)
-    ) {
+    let tierOneFired = false;
+    if (selLeaf && selLeaf !== previousActiveElement) {
       const selIndex = vim_info.lines.findIndex(
         (line) => line.element === selLeaf,
       );
       if (selIndex !== -1) {
         vim_info.active_line = selIndex;
-        return;
+        tierOneFired = true;
       }
     }
 
-    if (previousActiveElement) {
+    if (!tierOneFired && previousActiveElement) {
       let newIndex = vim_info.lines.findIndex(
         (line) => line.element === previousActiveElement,
       );
@@ -231,6 +242,24 @@ export const createRefreshLines = (handlers: EventHandlers) => {
         vim_info.active_line = newIndex;
       }
     }
+
+    // Keep ALL UI surfaces in step with the rebuilt array: the status bar
+    // text (rendered from vim_info.active_line + 1), the absolutely-positioned
+    // block-cursor overlay (geometric, anchored to lines[active_line]), and
+    // the body.dataset bridge consumed by the test harness. refreshLines is
+    // driven by MutationObserver, so it can fire AFTER the keydown handler's
+    // updateInfoContainer has already run — without re-rendering here, any
+    // active_line shift this function makes is invisible to the user (status
+    // bar shows the previous block) and to the test harness (overlay
+    // geometry stays frozen on the previous block). updateInfoContainer is
+    // a pure render plus a syncVimInfoToDOM call at its tail; safe in any
+    // observer context.
+    //
+    // The sync MUST cover all three tiers (selection-leaf, identity,
+    // block_id); an earlier draft returned early from the selection-leaf
+    // tier and skipped the sync, leaving the bridge frozen at the
+    // pre-mutation active_line even though vim_info itself was correct.
+    updateInfoContainer();
   };
 };
 
@@ -266,14 +295,78 @@ export const createSetLines = (
       line.element.addEventListener("click", handlers.handleClick, true);
     });
 
-    // Set up MutationObserver to detect new lines
-    const observer = new MutationObserver(() => {
+    // Reconcile active_line against the current DOM selection. Cheap; safe
+    // to call repeatedly. Returns true iff it wrote a new active_line. When
+    // it does, all UI surfaces are re-rendered via updateInfoContainer so
+    // the status bar, block-cursor overlay, and dataset bridge agree with
+    // vim_info.
+    const reconcileFromSelection = (): boolean => {
+      const sel = window.getSelection();
+      const anchor = sel?.anchorNode ?? null;
+      if (!anchor) return false;
+      const el =
+        anchor.nodeType === Node.ELEMENT_NODE
+          ? (anchor as Element)
+          : anchor.parentElement;
+      const leaf = el?.closest('[contenteditable="true"]') ?? null;
+      if (!leaf) return false;
+      const { lines, active_line } = vim_info;
+      if (lines[active_line]?.element === leaf) return false;
+      const idx = lines.findIndex((line) => line.element === leaf);
+      if (idx === -1) return false;
+      vim_info.active_line = idx;
+      updateInfoContainer();
+      return true;
+    };
+
+    // Set up MutationObserver to detect new lines AND text-only mutations.
+    // childList alone misses Notion's text-only undo (e.g. `A` → type → Esc →
+    // j → u: undo rewinds the typed characters without removing/adding any
+    // leaf, so refreshLines never re-runs and active_line stays on the post-j
+    // block while the DOM cursor jumps back to where the edit happened).
+    // Adding characterData covers that case while still firing on the insert
+    // and removal paths.
+    //
+    // Filter our own UI surfaces (status bar, block-cursor overlay) out of
+    // observed mutations. updateInfoContainer (called from refreshLines)
+    // rewrites the status bar text and sometimes nudges the overlay's
+    // textContent (zero-width-space measurement trick); both are observable
+    // mutations on document.body subtree. Without this filter, refreshLines
+    // → updateInfoContainer → mutation → MutationObserver → refreshLines is
+    // an infinite loop that hangs the page on every keystroke.
+    const ownUiContains = (node: Node | null): boolean => {
+      let cur: Node | null = node;
+      while (cur && cur !== document.body) {
+        if (cur instanceof Element) {
+          if (
+            cur.classList.contains("vim-info-container") ||
+            cur.classList.contains("vim-mode") ||
+            cur.classList.contains("vim-block-cursor")
+          ) {
+            return true;
+          }
+        }
+        cur = cur.parentNode;
+      }
+      return false;
+    };
+    const observer = new MutationObserver((mutations) => {
+      const relevant = mutations.some((m) => !ownUiContains(m.target));
+      if (!relevant) return;
       refreshLines();
     });
 
     observer.observe(document.body, {
       childList: true,
       subtree: true,
+      characterData: true,
     });
+
+    // Selection-change reconciliation: catches cursor moves that are not
+    // accompanied by any DOM mutation (Notion can move the DOM cursor as a
+    // pure focus shuffle between blocks). Pairs with the selection-leaf-as
+    // -truth tier inside refreshLines, which handles the mutation-driven
+    // path; this listener handles the remainder.
+    document.addEventListener("selectionchange", reconcileFromSelection);
   };
 };

--- a/test/e2e/insert-open-line.spec.ts
+++ b/test/e2e/insert-open-line.spec.ts
@@ -367,7 +367,7 @@ test.describe.serial("Insert / Open Line — block types & edge cases", () => {
   // =========================================================================
 
   // BUG-003: o→type→Esc→k returns to wrong block (off by 1)
-  test.fail("o on bullet + type + Esc, then k returns to original", async ({ extensionPage: page }) => {
+  test("o on bullet + type + Esc, then k returns to original", async ({ extensionPage: page }) => {
     await goToBlock(page, "Bullet item 1");
 
     await pressKeys(page, "o");
@@ -390,7 +390,7 @@ test.describe.serial("Insert / Open Line — block types & edge cases", () => {
   });
 
   // BUG-003: o→type→Esc→k returns to wrong block (off by 1)
-  test.fail("o on nested todo + type + Esc, then k returns to original", async ({ extensionPage: page }) => {
+  test("o on nested todo + type + Esc, then k returns to original", async ({ extensionPage: page }) => {
     await goToBlock(page, "Nested todo child");
 
     await pressKeys(page, "o");
@@ -583,7 +583,7 @@ test.describe.serial("Insert / Open Line — block types & edge cases", () => {
   // on N, mirroring the BUG-040 family of post-undo desyncs cataloged in
   // docs/known-bugs.md. Verified pre-existing on commit 0677b34 (parent of
   // 2e5ee72) — not caused by the A/o setCursorPastLineEnd fix.
-  test.fail("A on numbered item + type + Esc, j moves to next item", async ({ extensionPage: page }) => {
+  test("A on numbered item + type + Esc, j moves to next item", async ({ extensionPage: page }) => {
     await goToBlock(page, "Numbered item 1");
 
     await pressKeys(page, "Shift+a");
@@ -699,7 +699,7 @@ test.describe.serial("Insert / Open Line — block types & edge cases", () => {
   // desync family as BUG-040 (refreshLines doesn't follow Notion's
   // undo-driven leaf restoration). Verified pre-existing on commit
   // 0677b34 — not caused by the A/o setCursorPastLineEnd fix.
-  test.fail("o + Esc immediately creates and keeps empty line", async ({ extensionPage: page }) => {
+  test("o + Esc immediately creates and keeps empty line", async ({ extensionPage: page }) => {
     const beforeTexts = await getAllBlockTexts(page);
     const beforeCount = beforeTexts.length;
 
@@ -728,7 +728,7 @@ test.describe.serial("Insert / Open Line — block types & edge cases", () => {
   // count). Pre-existing — not caused by the A/o setCursorPastLineEnd
   // fix; the cleanup `u` lands DOM cursor on block N-1 while
   // vim_info.active_line stays on N.
-  test.fail("O + Esc immediately on nested bullet", async ({ extensionPage: page }) => {
+  test("O + Esc immediately on nested bullet", async ({ extensionPage: page }) => {
     const beforeTexts = await getAllBlockTexts(page);
     const beforeCount = beforeTexts.length;
 


### PR DESCRIPTION
  # fix(line-management): track post-undo cursor jumps in refreshLines

  ## 🔄 Changes                                                                                                                                   
  - **`src/content_scripts/core/line-management.ts`** — `createRefreshLines` reorganized into a documented three-tier recovery: (1) 
  selection-leaf-as-truth, (2) element-identity, (3) `block_id` fallback. Tier-1's `!existingElements.has(selLeaf)` "fresh leaf only" guard is    
  dropped so post-undo cursor jumps to *pre-existing* leaves are also caught. Tier-1 no longer early-returns — execution falls through and a 
  single `updateInfoContainer()` runs at the tail to keep status bar / block-cursor overlay / `dataset.vimtionState` bridge in step.              
  - **`createSetLines`** — `MutationObserver` now also watches `characterData: true` (catches text-only undo). Observer callback filters mutations
   whose target is inside our own UI surfaces (`.vim-info-container`, `.vim-mode`, `.vim-block-cursor`) — without this, calling                   
  `updateInfoContainer()` from `refreshLines` is an infinite loop. Added `selectionchange` listener with a `reconcileFromSelection` helper to 
  catch Notion focus shuffles between blocks that happen with no DOM mutation.                                                                    
  - **`test/e2e/insert-open-line.spec.ts`** — 5 markers flipped to plain `test()`:
    - BUG-040: `:586` (`A` on numbered + Esc + j + u), `:702` (`o` + Esc immediately + u), `:731` (`O` + Esc immediately on nested bullet + u)    
    - BUG-003 regression coverage: `:370` (`o` on bullet + Esc + k), `:393` (`o` on nested todo + Esc + k)                                        
  - **`docs/known-bugs.md`** — BUG-040 status updated to `RESOLVED — PARTIAL` (3 of 4 fingerprints fixed by `c0b111c`); BUG-003 entry annotated   
  with the additional regression coverage from `c0b111c`'s broadened selection-leaf path.                                                         
                                                                                                                                                  
  **Preserved recovery paths**: BUG-001 rapid-j/k stays on tier-2 because `setActiveLine`'s `setCursorPosition` tail leaves `selLeaf ===          
  previousActiveElement`, so tier-1's `selLeaf !== previousActiveElement` guard skips. BUG-003 fresh-leaf insertion still hits tier-1 (broadened, 
  but still fires). BUG-012/013 markdown-shortcut leaf-swap still hits tier-3 (`block_id`) because the original element becomes detached.
                                                                                                                                                  
  ## ⚠️  Breaking Changes                                 
  - [ ] None — no public API changes; only internal reconciliation logic + new defensive listeners. All existing recovery paths preserved.
                                                                                                                                                  
  ## 🔍  How to Reproduce
  ```bash                                                                                                                                         
  git fetch origin                                        
  git checkout fix/bug-040-undo-refreshlines                                                                                                      
  npm ci                                                  
  npx tsc --noEmit                                                            # → exit 0                                                          
  npm run lint                                                                # → exit 0                                                          
  npm run build                                                               # → dist/ generated                                                 
  npx playwright test test/e2e/insert-open-line.spec.ts:586 \                                                                                     
                      test/e2e/insert-open-line.spec.ts:702 \                                                                                     
                      test/e2e/insert-open-line.spec.ts:731 \                                                                                     
                      test/e2e/insert-open-line.spec.ts:370 \                                                                                     
                      test/e2e/insert-open-line.spec.ts:393                   # → 5/5 strict-pass                                                 
  ```                                                                                                                                             
                                                                                                                                                  
  ## Notes                                                                                                                                        
  - **Test suite delta vs main**: 374 → **397 passed** (+23), 32 → **9 failed** (−23). Of the 23 newly-passing tests: 5 are this PR's marker 
  flips, the remaining 18 come from the broadened reconciliation incidentally fixing latent cases not previously catalogued (no markers to flip). 
  - **Out-of-scope partial**: BUG-040 fingerprint A (`o` inside code block + `u`) — `code-block-nav.spec.ts:362` cleanup `u` still trips the 
  cursor invariant. Notion's undo moves DOM cursor to the heading above the code block while `vim_info` stays in code block; tier-1 broadening    
  doesn't capture this. Marker preserved; status documented.
  - **Bisect attempt**: We tried trimming the new `selectionchange` listener and `characterData: true` to isolate the minimum required diff       
  (commit `d55a4f3` on this branch's reflog). Result was −81 passes / +22 failures cross-spec, confirming both additions are load-bearing for     
  cumulative state cleanliness across the suite. Reset to the full fix.  
  - **Two intermittent regressions on this PR vs main** (both pass standalone, fail only under cumulative cross-spec state in `npm test`):        
  `cursor-sync.spec.ts:186` (I→Esc→k after code block) and `scenario-markdown-chaos.spec.ts:213` (6-shortcut conversion chain). Tracked as TODO   
  below; net trade is +23 reliable passes for 2 intermittents.           
  - **House rules**: one bug per source commit, Conventional Commits ≤72 chars, no `BUG-xxx` references in `src/` (test/ comments retained for    
  history), all commits via `gc -y -i`.                                                                                                           
                                                                         
  ### TODO:                                                                                                                                       
  - [ ] File a new `docs/known-bugs.md` entry (e.g. BUG-046) for the 2 intermittent cross-spec regressions in `cursor-sync.spec.ts:186` and 
  `scenario-markdown-chaos.spec.ts:213`. Both pass standalone — root cause likely in the `selectionchange` listener accumulating handlers across  
  spec teardown/setup. Separate PR.
  - [ ] Code-block-specific reconciliation path for BUG-040 fingerprint A (`o` inside code block + `u`) — needs a recovery branch that prefers the
   code-block leaf over the post-undo DOM cursor when the latter lands outside the block. Separate PR.                                            
  - [ ] Pre-existing flag (also separate PR): `scenario-markdown-chaos.spec.ts:305` (table-walk +1 active_line drift on rapid j×5 after 6-shortcut
   chain) fails on `main` and on this branch alike — surfaced during bisect verification, not a regression. Worth its own `docs/known-bugs.md`    
  entry.                                                  
