### PR TITLE
chore: catalog post-#12 follow-up bugs and drop redundant updateBlockCursor calls

### DIFF
--- a/docs/known-bugs.md
+++ b/docs/known-bugs.md
@@ -274,3 +274,22 @@ violation naming the exact shortcut that broke (`## conversion + Esc`,
 - **Withdrawn**: 2026-05-03 — implementer re-investigated on a clean baseline (no source changes) with a 3-scenario debug spec (clean Escape, H1-touched-then-Escape, accumulated activity then Escape). Cursor stayed on the target leaf in all three; vim_info and DOM agreed throughout.
 - **Misattribution origin**: The Escape→H1 behavior was a coupling artifact of the partial BUG-043 WIP (page-title wrapper filter + bare `vim_info.active_line = 0` in `createSetLines`). With the filter applied, `lines[0]` became the real H1 leaf rather than the inert wrapper, and the partial WIP's init paths primed Notion's focus tracking onto H1. Neither happens without the partial WIP.
 - **Implication for BUG-043**: page-title-filter approach is viable on its own; no Escape reconciliation needed.
+
+## BUG-045: Table-walk drift after 6-markdown-shortcut chain (rapid j×5 → +1 active_line)
+
+- **Detected**: 2026-05-04 (surfaced during BUG-040 bisect verification on `d55a4f3`)
+- **Status**: Pre-existing — reproduces standalone on `main`, on `c0b111c`, and on the bisect attempt `d55a4f3` alike. Not introduced by any 2026-05-03 / 2026-05-04 sprint.
+- **Test**: `scenario-markdown-chaos.spec.ts:305` (`Validate: walked block classes contain expected sequence`)
+- **Reproduction**: After `convertOnSpace` runs the 6-shortcut conversion chain (Rounds 1–6 in the same `scenario-markdown-chaos` test), press `j` rapidly 5 times to walk into the table region below. `vim_info.active_line` lands one block past where the DOM cursor is — the walked-block-class sequence is off by one.
+- **Suspected root cause**: Likely interacts with the same identity/block_id recovery paths that BUG-001 / BUG-040 exercise, but specifically the rapid-j burst that crosses from the post-conversion region into a table block. Tables wrap their contenteditable cells differently from regular blocks; the recovery's wrapper-skip may not match table-cell shape.
+- **Severity**: Low–Medium — rare in practice (requires sequential markdown conversions then immediate rapid j into a table), but indicates a gap in our recovery paths for table-cell DOM shape.
+
+## BUG-046: Cross-spec cumulative flake under `npm test` full-suite run
+
+- **Detected**: 2026-05-03 (surfaced during BUG-040 PR #12 final verification on `c0b111c`)
+- **Status**: Accepted as known intermittent under `npm test` full-suite; both tests pass standalone or on retry.
+- **Tests**: `cursor-sync.spec.ts:186` (`I → Escape → k on text after code block stays consistent`) and `scenario-markdown-chaos.spec.ts:213` (`Conversion chain: 6 markdown shortcuts in sequence`).
+- **Reproduction**: Run `npm test` (full Playwright suite). Both tests fail intermittently in the full-suite run on `c0b111c` and later. Re-running either test in isolation passes cleanly. The bisect attempt on `d55a4f3` (which removed the new `selectionchange` listener and `characterData: true` from the MutationObserver) fixed these two but caused 22 other failures and 81 total test losses, confirming the new listeners are load-bearing for cross-spec state cleanliness elsewhere.
+- **Suspected root cause**: The `selectionchange` listener and `characterData`-watching MutationObserver added in `c0b111c` likely accumulate state or fire mid-teardown across spec boundaries, contaminating the next spec's setup. Specifically: `selectionchange` listeners attached across page navigations may not be detached cleanly when Playwright reuses contexts, and the broadened observer fires on mid-teardown text mutations that wouldn't happen in a real session.
+- **Severity**: Low — only triggers under cumulative cross-spec state in CI-like full-suite runs. Real users with single-page sessions are not affected. Net trade was +23 reliable passes for these 2 intermittents (PR #12).
+- **Possible fix directions**: Detach `selectionchange` on page unload; rate-limit or debounce `reconcileFromSelection`; narrow the `characterData` observer to specific subtree roots; or re-architect the reconciliation so it doesn't need either listener.

--- a/src/content_scripts/navigation/scroll.ts
+++ b/src/content_scripts/navigation/scroll.ts
@@ -2,7 +2,7 @@
  * Scroll and viewport navigation (Ctrl+d, Ctrl+u, Ctrl+f, Ctrl+b, gg, G)
  */
 
-import { setCursorPosition, updateBlockCursor } from "../cursor";
+import { setCursorPosition } from "../cursor";
 import { setActiveLine } from "../core/line-management";
 
 export const findScrollableContainer = (): HTMLElement => {
@@ -92,7 +92,6 @@ export function createJumpToTop(updateInfoContainer: () => void) {
     setTimeout(() => {
       vim_info.desired_column = 0;
       setActiveLine(0);
-      updateBlockCursor();
       updateInfoContainer();
     }, 10);
   };
@@ -137,7 +136,6 @@ export function createJumpToBottom(
       if (targetElement) {
         setCursorPosition(targetElement, 0);
         targetElement.focus({ preventScroll: true });
-        updateBlockCursor();
         updateInfoContainer();
       }
     }, 10);

--- a/src/content_scripts/vim.ts
+++ b/src/content_scripts/vim.ts
@@ -506,7 +506,6 @@ const handleClick = (e: MouseEvent) => {
         // Update active line without moving cursor
         vim_info.active_line = lineIndex;
         vim_info.desired_column = cursorPos;
-        updateBlockCursor();
         updateInfoContainer();
       }
     }


### PR DESCRIPTION
# chore: catalog post-#12 follow-up bugs and drop redundant updateBlockCursor calls
                                                                                                                            
## 🔄 Changes                                                                                                              
- **`docs/known-bugs.md`** — two new entries to close the loop on PR #12's TODOs:
  - **BUG-045** — Table-walk +1 `active_line` drift after the 6-markdown-shortcut chain in                                 
`scenario-markdown-chaos.spec.ts:305`. Pre-existing; reproduces standalone on `main`, on `c0b111c`, and on the bisect      
attempt `d55a4f3` alike. Surfaced during BUG-040 bisect verification, not a regression from any 2026-05-03 / 2026-05-04    
sprint.                                                                                                                    
  - **BUG-046** — Cross-spec cumulative flake under `npm test` full-suite for `cursor-sync.spec.ts:186` and
`scenario-markdown-chaos.spec.ts:213`. Both pass standalone or on retry. Likely caused by the `selectionchange` listener   
and `characterData`-watching MutationObserver added in `c0b111c` (PR #12) accumulating state or firing mid-teardown across
spec boundaries. The bisect that removed both listeners fixed these two tests but broke 22 others, confirming the new      
listeners are load-bearing for cross-spec state cleanliness elsewhere.
- **`src/content_scripts/navigation/scroll.ts` + `src/content_scripts/vim.ts`** — drop three redundant
`updateBlockCursor()` calls that ran immediately before `updateInfoContainer()`. `updateInfoContainer()` already calls     
`updateBlockCursor()` internally (`src/content_scripts/ui/info-container.ts:80`), so the prior calls were dead. Sites:
`scroll.ts:95` (`createJumpToTop`), `scroll.ts:140` (`createJumpToBottom`), `vim.ts:509` (`handleClick`). Also removes the 
now-unused `updateBlockCursor` import from `scroll.ts`. Reviewer's non-blocking nit from the v1.5.4 sprint.
                                                                                                                            
## ⚠️  Breaking Changes
- [ ] None — docs-only addition + dead-code removal. No behavior change.
                                                                                                                           
## 🔍  How to Reproduce
```bash                                                                                                                    
git fetch origin                                       
git checkout chore/docs-cleanup-and-nits
npm ci                                                                                                                     
npx tsc --noEmit   # → exit 0
npm run lint       # → exit 0                                                                                              
npm run build      # → dist/ generated                 
```                                                                                                                        
                                                       
## Notes
- The redundant-call removal is purely dead-code: each removed `updateBlockCursor()` was called one statement before
`updateInfoContainer()`, which calls `updateBlockCursor()` itself. No runtime delta, so a full e2e run is unnecessary.     
- Both BUG-045 and BUG-046 are documented as separate from this PR's scope — the docs entries exist so future sprints can
pick them up with full context. No source fix attempted here.                                                              
- The other reviewer nit from v1.5.4 (`handleClick` wrapper-skip for direct page-title clicks) is intentionally NOT folded
in — it's a correctness change with edge-case behavior that benefits from its own test, not a redundant-call removal.      
Listed as TODO below.                                  
- House rules followed: one concern per commit, Conventional Commits ≤72 chars, no `BUG-xxx` references in `src/`, all     
commits via `gc -y -i`.                                                                                                    

### TODO:                                                                                                                  
- [ ] **BUG-046 root-cause investigation** — possible fix directions documented in the entry: detach `selectionchange` on
page unload; rate-limit or debounce `reconcileFromSelection`; narrow the `characterData` observer to specific subtree      
roots; or re-architect the reconciliation so it doesn't need either listener.
- [ ] **BUG-045 fix** — needs investigation of how the recovery paths (identity / `block_id`) handle table-cell DOM shape, 
which differs from regular block wrappers.                                                                                 
- [ ] **`handleClick` wrapper-skip for direct page-title clicks** — the deferred v1.5.4 reviewer nit. When a user clicks
the page-title `<div role="group">` wrapper itself (rather than the inner H1 text), `lineIndex` lands on the wrapper, but  
the DOM cursor goes to the H1 leaf — desync. Either route through `setActiveLine` or apply an `isWrapperLine`-style skip in
 `handleClick`.                                                                                                            
- [ ] **BUG-040 fingerprint A** — the still-failing `code-block-nav.spec.ts:362` (`o` inside code block + `u`) needs a
code-block-specific reconciliation path. Tracked in BUG-040 entry, deferred from PR #12.                                   
