### PR TITLE
Close BUG-040 fingerprint A: undo-scoped tier-0 anchor

### DIFF
--- a/docs/known-bugs.md
+++ b/docs/known-bugs.md
@@ -224,20 +224,22 @@ violation naming the exact shortcut that broke (`## conversion + Esc`,
 
 ## BUG-040: Post-undo cursor desync after o / O / A insert (broader than code blocks)
 
-- **Status**: **RESOLVED — PARTIAL**: 3 of 4 fingerprints fixed by `c0b111c`. Code-block-specific case (`o` inside code block + `u`) remains: Notion's undo moves DOM cursor to the heading above the code block while vim_info stays in code block — tier-1 broadening doesn't capture this. Test marker preserved at `code-block-nav.spec.ts:362`. Future work: needs code-block-specific reconciliation path.
+- **Status**: **RESOLVED** — 3 of 4 fingerprints fixed by `c0b111c` (2026-05-03), final code-block fingerprint A fixed 2026-05-04 by an undo-scoped tier-0 in `core/line-management.ts:createRefreshLines` plus a non-mutating neighbour-rect measurement in `cursor/block-cursor.ts`.
 - **Detected**: 2026-05-03
 - **Resolved (partial)**: 2026-05-03
+- **Resolved (full)**: 2026-05-04
 - **Source**: Surfaced during BUG-011 fix work (see commit `6614210`); scope broadened during e07b3e5 verification.
 - **Reproduction patterns** (all fingerprint-identical):
-  - Inside a code block: `o` → type → `u`. DOM cursor lands on the heading above; `vim_info.active_line` still points at the code-block leaf. **Still failing strict** (`code-block-nav.spec.ts:362`); marker preserved.
+  - Inside a code block: `o` → type → `u`. DOM cursor lands on the heading above; `vim_info.active_line` still points at the code-block leaf. **Fixed** (2026-05-04, `code-block-nav.spec.ts:354`).
   - On a numbered/regular/nested bullet item: `A` → type → `Esc` → `j` → `u`. `vim_info.active_line` advances; DOM cursor stays one block back. **Fixed** (`insert-open-line.spec.ts:586`).
   - On any insert variant: `o` → `Esc` (immediately, empty new line) → `u`. `vim_info.lines.length` (95) outpaces actual DOM editable count (94) — refreshLines missed the undo-driven leaf removal. **Fixed** (`insert-open-line.spec.ts:702`).
   - On a nested bullet: `O` → `Esc` immediately → `u`. Same fingerprint. **Fixed** (`insert-open-line.spec.ts:731`).
-- **Root cause**: `document.execCommand("undo")` rewinds Notion's DOM mutations (including leaf insertions/restorations), but the previous refreshLines/active_line reconciliation didn't follow undo-driven cursor jumps to pre-existing leaves — `vim_info` kept the post-insert state while DOM rolled back.
-- **Fix**: `c0b111c` broadens tier-1 (selection-leaf) recovery in `core/line-management.ts:createRefreshLines` to catch undo cursor-jumps to pre-existing leaves, and adds a characterData MutationObserver + `selectionchange` listener for the no-mutation cases. Three-tier recovery (selection-leaf / identity / block_id) preserved.
+- **Root cause**: `document.execCommand("undo")` rewinds Notion's DOM mutations (including leaf insertions/restorations), but the previous refreshLines/active_line reconciliation didn't follow undo-driven cursor jumps to pre-existing leaves — `vim_info` kept the post-insert state while DOM rolled back. For the code-block fingerprint A specifically, Notion's undo additionally relocates the DOM cursor up to the heading above the code block, ~200ms after the keypress; the strict cursor-invariant check fires at ~50ms post-keypress, catching the transient mismatch window.
+- **Fix**:
+  - `c0b111c` (2026-05-03): broadens tier-1 (selection-leaf) recovery in `core/line-management.ts:createRefreshLines` to catch undo cursor-jumps to pre-existing leaves; adds a characterData MutationObserver + `selectionchange` listener for the no-mutation cases. Closes 3 of 4 fingerprints.
+  - 2026-05-04: adds a tier-0 code-block anchor in `createRefreshLines`, scoped to the post-undo settle window opened by `undo()` in `vim.ts` via `__vimtionUndoSettleUntil` (500ms). When previousActiveElement was inside a code block AND the post-mutation DOM selection has wandered outside any code block, restore active_line to the code-block leaf and re-anchor the DOM cursor inside it. Scoping to the undo window keeps click-driven navigation OUT of a code block from being fought. Pairs with a non-mutating neighbour-rect cursor measurement in `cursor/block-cursor.ts` that replaces the zws round-trip on interior code-block carets — the zws path used to cascade through Notion's PrismJS tokenizer and form an infinite loop the moment tier-0 forced the caret onto a code-block leaf.
 - **Verified pre-existing**: Reproduced on `0677b34` (parent of A/o `setCursorPastLineEnd` fix `2e5ee72`), so this was NOT a regression from any 2026-05-03 sprint commit.
-- **Remaining work**: The code-block `o` + `u` fingerprint (`code-block-nav.spec.ts:362`) needs separate investigation — Notion's undo for code-block inserts moves DOM cursor to the heading above the code block, an interaction the current selection-leaf recovery doesn't capture. Marker stays until that case is addressed.
-- **Severity**: Was Medium-High — broader than initially scoped; affects A/o/O across most block types after undo. Three of four fingerprints now resolved.
+- **Severity**: Was Medium-High — broader than initially scoped; affects A/o/O across most block types after undo. All four fingerprints now resolved.
 
 ## BUG-041: ``` markdown shortcut → code block conversion leaves cursor desynced
 

--- a/docs/known-bugs.md
+++ b/docs/known-bugs.md
@@ -286,6 +286,24 @@ violation naming the exact shortcut that broke (`## conversion + Esc`,
 - **Suspected root cause**: Likely interacts with the same identity/block_id recovery paths that BUG-001 / BUG-040 exercise, but specifically the rapid-j burst that crosses from the post-conversion region into a table block. Tables wrap their contenteditable cells differently from regular blocks; the recovery's wrapper-skip may not match table-cell shape.
 - **Severity**: Low–Medium — rare in practice (requires sequential markdown conversions then immediate rapid j into a table), but indicates a gap in our recovery paths for table-cell DOM shape.
 
+## BUG-047: `x` (delete-character) inside code block is broken — block deletion in headed, letter insertion in headless
+
+- **Detected**: 2026-05-04 (manual report from user during BUG-040 fingerprint A verification)
+- **Status**: **OPEN.** No test marker yet; reproduction was via a throwaway script.
+- **Reproduction (headed/manual)**: Inside a code block in normal mode, position cursor anywhere, press `x`. The **entire code block is deleted** instead of one character.
+- **Reproduction (headless/automated)**: Same flow. The `x` keystroke is **inserted as the literal character 'x'** at the cursor position; the code block grows by one character. (Verified in throwaway repro spec: `"function hello() {"` → `"function hello() {x"`, length 61 → 62.)
+- **Root cause hypothesis**: `deleteCharacter()` in `src/content_scripts/vim.ts:350` uses `document.execCommand("cut")` after selecting one char in the current element's text node. For a code-block leaf:
+  - **Headed (Notion live)**: Notion's own `cut` handler treats the code-block contenteditable as a unit and removes the whole block (same way Cmd+X on a code block does).
+  - **Headless (Playwright)**: `execCommand("cut")` returns false silently (clipboard access denied / event not fully synthesized), the selection is left dangling, and the original `x` keydown bubbles through to Notion's text-input pipeline, which inserts the letter at the caret. Either vim's `preventDefault` doesn't fire, or Notion's `beforeinput` listener bypasses it.
+- **Why both paths break**: `deleteCharacter` was written for plain text leaves, where one-char selection + `cut` produces the right behavior. Code blocks need a code-block-specific path that uses `Range`-and-`Text`-mutation directly (analogous to `openLineBelowInCodeBlock` in `src/content_scripts/navigation/code-block.ts`), bypassing both Notion's clipboard handler and the platform clipboard altogether.
+- **Severity**: **High** in headed (data loss — the user's whole code block is destroyed by a single `x`). High in headless too, but as a different fingerprint. Affects every code-block user.
+- **Affects**: `x` (and likely `X` via `deleteCharacterBefore`, same pattern at `vim.ts:376`). Probably also `dd` / `D` / motion-delete inside code blocks — needs verification.
+- **Fix sketch**: Add a code-block branch in `deleteCharacter` / `deleteCharacterBefore` that:
+  1. Computes the target offset within the code-block textContent.
+  2. Uses `Range` + direct text-node manipulation to remove the character in place.
+  3. Dispatches an `input` event (`bubbles: true, inputType: "deleteContentForward"`) so Notion's renderer / undo stack stays consistent.
+  4. Bypass `execCommand("cut")` — clipboard write is not part of Vim's `x` semantics anyway (`x` puts the char in the unnamed register, not the system clipboard).
+
 ## BUG-046: Cross-spec cumulative flake under `npm test` full-suite run
 
 - **Detected**: 2026-05-03 (surfaced during BUG-040 PR #12 final verification on `c0b111c`)

--- a/src/content_scripts/core/line-management.ts
+++ b/src/content_scripts/core/line-management.ts
@@ -184,7 +184,17 @@ export const createRefreshLines = (handlers: EventHandlers) => {
         elem.closest("[data-block-id]")?.getAttribute("data-block-id") ?? null,
     }));
 
-    // Recover active line. Three tiers, in priority order:
+    // Recover active line. Tiers, in priority order:
+    //
+    //   0. Code-block anchor (undo-scoped): when undo() opened the
+    //      __vimtionUndoSettleUntil window AND previousActiveElement was
+    //      inside a code block (still attached) AND the post-mutation
+    //      DOM selection has wandered outside any code block, restore
+    //      active_line to the code-block leaf and re-anchor the DOM
+    //      cursor inside it. Catches the post-undo case where Notion's
+    //      undo for code-block inserts moves the DOM cursor up to the
+    //      heading above the block. Scoped to the post-undo window so
+    //      click-driven navigation OUT of a code block is not fought.
     //
     //   1. Selection-leaf-as-truth: the DOM selection's leaf is in the
     //      rebuilt array AND differs from previousActiveElement. This covers
@@ -203,13 +213,16 @@ export const createRefreshLines = (handlers: EventHandlers) => {
     //      survives on a replacement node (markdown-shortcut swap territory,
     //      e.g. paragraph→heading conversion).
     //
-    // The (1) → (2) → (3) ordering matters. A previous narrow form of (1)
-    // gated on "selLeaf is brand new" to keep rapid j/k off this path, but
-    // that gate also blocked the post-undo cursor-jump cases where the new
-    // leaf is pre-existing. Tier 1 is now safe to broaden because rapid j/k
-    // ends with setCursorPosition leaving selLeaf === lines[active_line]
-    // .element === previousActiveElement, so the `selLeaf !==
-    // previousActiveElement` guard alone is enough to keep that path off.
+    // The (0) → (1) → (2) → (3) ordering matters. Tier 0 must precede tier 1
+    // because tier 1 would happily follow Notion's stray selection out of
+    // the code block and produce the post-undo desync. A
+    // previous narrow form of (1) gated on "selLeaf is brand new" to keep
+    // rapid j/k off this path, but that gate also blocked the post-undo
+    // cursor-jump cases where the new leaf is pre-existing. Tier 1 is now
+    // safe to broaden because rapid j/k ends with setCursorPosition leaving
+    // selLeaf === lines[active_line].element === previousActiveElement, so
+    // the `selLeaf !== previousActiveElement` guard alone is enough to
+    // keep that path off.
     const selection = window.getSelection();
     const selAnchor = selection?.anchorNode ?? null;
     const selAnchorEl =
@@ -219,7 +232,31 @@ export const createRefreshLines = (handlers: EventHandlers) => {
     const selLeaf = selAnchorEl?.closest('[contenteditable="true"]') ?? null;
 
     let tierOneFired = false;
-    if (selLeaf && selLeaf !== previousActiveElement) {
+
+    // Tier 0: undo-scoped code-block anchor. Only active inside the post-
+    // undo window opened by undo() in vim.ts.
+    const undoSettleUntil =
+      (window as Window & { __vimtionUndoSettleUntil?: number })
+        .__vimtionUndoSettleUntil ?? 0;
+    const inUndoWindow = Date.now() < undoSettleUntil;
+    if (
+      inUndoWindow &&
+      previousActiveElement &&
+      isInsideCodeBlock(previousActiveElement) &&
+      selLeaf &&
+      !isInsideCodeBlock(selLeaf)
+    ) {
+      const prevIndex = vim_info.lines.findIndex(
+        (line) => line.element === previousActiveElement,
+      );
+      if (prevIndex !== -1) {
+        vim_info.active_line = prevIndex;
+        setCursorPosition(previousActiveElement as Element, 0);
+        tierOneFired = true;
+      }
+    }
+
+    if (!tierOneFired && selLeaf && selLeaf !== previousActiveElement) {
       const selIndex = vim_info.lines.findIndex(
         (line) => line.element === selLeaf,
       );

--- a/src/content_scripts/cursor/block-cursor.ts
+++ b/src/content_scripts/cursor/block-cursor.ts
@@ -49,7 +49,63 @@ export const updateBlockCursor = () => {
     const inCodeBlock = isInsideCodeBlock(currentElement);
 
     if (inCodeBlock) {
-      // For code blocks on empty lines, temporarily insert a zero-width space to get the cursor position
+      // Try a non-mutating measurement first: span an adjacent character's
+      // range. For an interior caret (offset > 0 or offset < length), one
+      // of the neighbour spans gives a real rect we can position from. This
+      // avoids the zws round-trip below \u2014 Notion's PrismJS-based code-block
+      // highlighter cascades childList mutations on every text change, so a
+      // refresh-driven re-entry through this function would loop on any
+      // 0/0 caret position.
+      try {
+        if (
+          range.startContainer &&
+          range.startContainer.nodeType === Node.TEXT_NODE
+        ) {
+          const textNode = range.startContainer as Text;
+          const offset = range.startOffset;
+          const textLen = textNode.textContent?.length ?? 0;
+
+          let neighbourRect: DOMRect | null = null;
+          let useTrailingEdge = false;
+          if (offset > 0) {
+            const r = document.createRange();
+            r.setStart(textNode, offset - 1);
+            r.setEnd(textNode, offset);
+            const rr = r.getBoundingClientRect();
+            if (rr.height > 0) {
+              neighbourRect = rr;
+              useTrailingEdge = true;
+            }
+          }
+          if (!neighbourRect && offset < textLen) {
+            const r = document.createRange();
+            r.setStart(textNode, offset);
+            r.setEnd(textNode, offset + 1);
+            const rr = r.getBoundingClientRect();
+            if (rr.height > 0) {
+              neighbourRect = rr;
+            }
+          }
+
+          if (neighbourRect) {
+            const left = useTrailingEdge
+              ? neighbourRect.right
+              : neighbourRect.left;
+            blockCursor.style.display = "block";
+            blockCursor.style.left = `${left + window.scrollX}px`;
+            blockCursor.style.top = `${neighbourRect.top + window.scrollY}px`;
+            blockCursor.style.height = `${neighbourRect.height}px`;
+            return;
+          }
+        }
+      } catch (e) {
+        // Fall through to zws / elementRect handling
+      }
+
+      // Empty code-block line \u2014 temporarily insert a zero-width space to
+      // get a measurable rect. Reachable only when the leaf has no
+      // characters around the caret, so PrismJS has nothing to recompute
+      // and the mutation cascade that would loop here doesn't fire.
       try {
         if (
           range.startContainer &&

--- a/src/content_scripts/vim.ts
+++ b/src/content_scripts/vim.ts
@@ -1808,6 +1808,18 @@ const undo = () => {
   // Check if we need to undo multiple operations (from grouped deletions)
   const count = vim_info.undo_count > 0 ? vim_info.undo_count : 1;
 
+  // Open a short window in which refreshLines's tier-0 code-block anchor
+  // is allowed to fire. Notion's undo for code-block inserts moves the DOM
+  // cursor up to the heading above the block while vim_info is still
+  // tracking the code-block leaf. The protection re-anchors the cursor
+  // inside the block. Scoping it to the post-undo window keeps it away
+  // from regular navigation paths (clicks, motion keys), which would
+  // otherwise be disturbed by the same logic. 500ms covers Notion's typical
+  // undo-settle latency.
+  (
+    window as Window & { __vimtionUndoSettleUntil?: number }
+  ).__vimtionUndoSettleUntil = Date.now() + 500;
+
   // Perform undo operations
   performUndoOperations(count);
 

--- a/test/e2e/code-block-nav.spec.ts
+++ b/test/e2e/code-block-nav.spec.ts
@@ -351,15 +351,7 @@ test.describe("Code block navigation", () => {
   // Code block: o/O behavior
   // =========================================================================
 
-  // BUG-011: the actual `o` insertion now works (Range + Text("\n") +
-  // dispatched input event), and the test's two content assertions pass
-  // (afterLines.length === beforeLineCount + 1 and "NEW_CODE_LINE" appears
-  // on its own line). What still fails is the strict cursor-invariant
-  // during the cleanup `u`: Notion's undo moves the DOM cursor to the
-  // heading above while vim_info.active_line stays on the code block —
-  // a post-undo cursor-desync issue (BUG-001 family), not BUG-011.
-  // Marker stays until that desync is addressed separately.
-  test.fail("o inside code block creates new line below within block", async ({ extensionPage: page }) => {
+  test("o inside code block creates new line below within block", async ({ extensionPage: page }) => {
     await goToBlock(page, "Section 8: Code block");
     await pressKeys(page, "j"); // code block line 0
     await page.waitForTimeout(200);


### PR DESCRIPTION
# Close BUG-040 fingerprint A — post-undo cursor desync inside code blocks                                                    
                                                                                                                              
## 🔄 Changes                                       
                                                                                                                              
- After `o` inside a code block + type + `Esc` + `u`, vim's `active_line` no longer drifts off the code-block leaf when       
Notion's undo handler relocates the DOM caret up to the heading above the block. Tracking and the visible cursor now stay     
anchored inside the block, matching user intent and what Vim's `u` is supposed to do.                                         
- The reconciliation that makes that work is **scoped to a 500ms post-undo window** opened by `undo()`
(`__vimtionUndoSettleUntil`). Click-driven and motion-driven navigation OUT of a code block keeps the same baseline behavior —
 the new tier-0 anchor in `createRefreshLines` cannot fire outside the undo window, so it can't fight legitimate exits.
- Replaced the zero-width-space round-trip in `updateBlockCursor` with a non-mutating neighbour-rect measurement for interior 
code-block carets. The zws path mutated text node content, which Notion's PrismJS tokenizer reacted to with cascading         
`childList` mutations — the moment the new tier-0 anchor pinned the caret on a code-block leaf, that cascade became an
infinite loop. Neighbour-rect avoids touching the DOM at all; zws is kept as a fallback for genuinely empty code-block lines. 
- Flipped `test.fail` off the `o inside code block creates new line below within block` test in `code-block-nav.spec.ts` (now
passes strict).                                                                                                               
- Updated `docs/known-bugs.md`: BUG-040 → RESOLVED (all four fingerprints) and added BUG-047 documenting a separate code-block
 bug surfaced during this PR's manual verification (`x` deletes the whole block in headed mode / inserts the literal letter in
 headless — same `deleteCharacter` + `execCommand("cut")` root cause, no fix in this PR).
                                                                                                                              
## ⚠️  Breaking Changes                             
- [ ]                                        
                                                                                                                               
## 🔍  How to Reproduce
```bash
# Run the previously-failing test (strict-passes 3/3 with this PR; baseline failed):                                          
npx playwright test --config test/playwright.config.ts \
  test/e2e/code-block-nav.spec.ts \                                                                                           
  -g "o inside code block" \                                                                                                  
  --project=e2e-headless --reporter=line     
                                                                                                                              
# Run the full code-block spec (21/22, remaining failure is pre-existing BUG-041):
npx playwright test --config test/playwright.config.ts \                                                                      
  test/e2e/code-block-nav.spec.ts --project=e2e-headless
                                                                                                                              
# Full e2e suite (416/420, three remaining failures all confirmed pre-existing on baseline):
npm test                                                                                                                      

# Lint / type-check / build:                                                                                                  
npx tsc --noEmit && npm run lint && npm run build   
                                                                                                                              
# Manual sanity-check in Chrome:
#   1. Open a Notion page with a code block.                                                                                  
#   2. Click into the heading above the code block, press Esc.
#   3. j  (enter code block first line)      
#   4. o, type "XYZ", Esc.                                                                                                    
#   5. u  →  cursor and status bar both stay inside the code block.
#      (Pre-fix baseline: status bar froze on the code-block line while                                                       
#       the DOM caret jumped up to the heading.)                                                                              
```                                          
                                                                                                                              
## Notes                                            
### TODO:                                    
- [ ] BUG-047 (`x` inside code block) — fix sketch in `docs/known-bugs.md`. Needs a code-block-specific `deleteCharacter` /
`deleteCharacterBefore` path that uses Range + Text mutation directly and dispatches a `deleteContentForward` `input` event,  
instead of routing through `document.execCommand("cut")`.
- [ ] Investigate whether the 500ms `__vimtionUndoSettleUntil` window is enough for slow machines / large pages; widen if any 
flake surfaces in CI under load.                                                                                              
- [ ] Once a Notion-auth secret lands in CI, drop the `test.fail` markers that were preserved only because of timing variance
and let strict invariants run there too.                                                                                      
