### PR TITLE
Fix `x` inside code blocks: stop destroying blocks / inserting literal 'x'                                                  

### DIFF
--- a/docs/e2e-test-catalog.md
+++ b/docs/e2e-test-catalog.md
@@ -485,7 +485,7 @@ Block types not already in operators-block-types.spec.ts.
 |---|------|-------------|--------|
 | 149-160 | i inserts text on {type} | All 12 types | Pass |
 
-## code-block-nav.spec.ts (21 tests, serial)
+## code-block-nav.spec.ts (23 tests, serial)
 
 ### j/k entering and within code block
 
@@ -567,6 +567,13 @@ Block types not already in operators-block-types.spec.ts.
 |---|------|--------|-------|
 | 20 | BUG-036: h in code block preserves visual column for subsequent j/k | Fail (expected) | h/l set desired_column to absolute textContent offset |
 | 21 | BUG-035: f in code block preserves visual column for subsequent j | Fail (expected) | f/F/t/T set desired_column to absolute textContent offset |
+
+### x in code block (BUG-047)
+
+| # | Test | Status | Notes |
+|---|------|--------|-------|
+| 22 | BUG-047: x at line-end position in code block does not destroy block or insert 'x' | Pass | Range-based delete + dispatched input event bypasses execCommand("cut") |
+| 23 | BUG-047: x in middle of code-block line deletes exactly one character | Pass | Positive case: same code path produces correct one-char delete |
 
 ## undo-redo.spec.ts (17 tests, serial)
 

--- a/docs/known-bugs.md
+++ b/docs/known-bugs.md
@@ -289,20 +289,17 @@ violation naming the exact shortcut that broke (`## conversion + Esc`,
 ## BUG-047: `x` (delete-character) inside code block is broken — block deletion in headed, letter insertion in headless
 
 - **Detected**: 2026-05-04 (manual report from user during BUG-040 fingerprint A verification)
-- **Status**: **OPEN.** No test marker yet; reproduction was via a throwaway script.
-- **Reproduction (headed/manual)**: Inside a code block in normal mode, position cursor anywhere, press `x`. The **entire code block is deleted** instead of one character.
-- **Reproduction (headless/automated)**: Same flow. The `x` keystroke is **inserted as the literal character 'x'** at the cursor position; the code block grows by one character. (Verified in throwaway repro spec: `"function hello() {"` → `"function hello() {x"`, length 61 → 62.)
-- **Root cause hypothesis**: `deleteCharacter()` in `src/content_scripts/vim.ts:350` uses `document.execCommand("cut")` after selecting one char in the current element's text node. For a code-block leaf:
+- **Status**: **RESOLVED** for `x` in `deleteCharacter`. `X` / `s` / `dd` / `D` / motion-delete still route through `execCommand("cut" | "delete")` and may share the same fingerprint — tracked separately.
+- **Resolution**: 2026-05-04. New helper `deleteCharacterInCodeBlock` in `src/content_scripts/navigation/code-block.ts` builds a `Range` over the target character via two `setCursorPosition` calls (so endpoints survive Notion's multi-span syntax-highlighted DOM), calls `range.deleteContents()`, and dispatches an `InputEvent("input", { inputType: "deleteContentForward" })` so Notion's renderer / undo stack stay consistent. `vim.ts` `deleteCharacter` branches to it when `isInsideCodeBlock(currentElement)`. The helper also refuses to delete a `\n` line separator, matching vim's "x doesn't cross line boundaries" semantics.
+- **Test markers**: `code-block-nav.spec.ts` — "BUG-047: x at line-end position in code block does not destroy block or insert 'x'" (covers headed data-loss and headless letter-insertion fingerprints), and "BUG-047: x in middle of code-block line deletes exactly one character" (positive case).
+- **Reproduction (pre-fix, headed/manual)**: Inside a code block in normal mode, position cursor anywhere, press `x`. The **entire code block is deleted** instead of one character.
+- **Reproduction (pre-fix, headless/automated)**: Same flow. The `x` keystroke is **inserted as the literal character 'x'** at the cursor position; the code block grows by one character. (Originally verified in throwaway repro spec: `"function hello() {"` → `"function hello() {x"`, length 61 → 62.)
+- **Root cause**: `deleteCharacter()` in `src/content_scripts/vim.ts` used `document.execCommand("cut")` after selecting one char in the current element's text node. For a code-block leaf:
   - **Headed (Notion live)**: Notion's own `cut` handler treats the code-block contenteditable as a unit and removes the whole block (same way Cmd+X on a code block does).
-  - **Headless (Playwright)**: `execCommand("cut")` returns false silently (clipboard access denied / event not fully synthesized), the selection is left dangling, and the original `x` keydown bubbles through to Notion's text-input pipeline, which inserts the letter at the caret. Either vim's `preventDefault` doesn't fire, or Notion's `beforeinput` listener bypasses it.
-- **Why both paths break**: `deleteCharacter` was written for plain text leaves, where one-char selection + `cut` produces the right behavior. Code blocks need a code-block-specific path that uses `Range`-and-`Text`-mutation directly (analogous to `openLineBelowInCodeBlock` in `src/content_scripts/navigation/code-block.ts`), bypassing both Notion's clipboard handler and the platform clipboard altogether.
-- **Severity**: **High** in headed (data loss — the user's whole code block is destroyed by a single `x`). High in headless too, but as a different fingerprint. Affects every code-block user.
-- **Affects**: `x` (and likely `X` via `deleteCharacterBefore`, same pattern at `vim.ts:376`). Probably also `dd` / `D` / motion-delete inside code blocks — needs verification.
-- **Fix sketch**: Add a code-block branch in `deleteCharacter` / `deleteCharacterBefore` that:
-  1. Computes the target offset within the code-block textContent.
-  2. Uses `Range` + direct text-node manipulation to remove the character in place.
-  3. Dispatches an `input` event (`bubbles: true, inputType: "deleteContentForward"`) so Notion's renderer / undo stack stays consistent.
-  4. Bypass `execCommand("cut")` — clipboard write is not part of Vim's `x` semantics anyway (`x` puts the char in the unnamed register, not the system clipboard).
+  - **Headless (Playwright)**: `execCommand("cut")` returns false silently (clipboard access denied / event not fully synthesized), the selection is left dangling, and the original `x` keydown bubbles through to Notion's text-input pipeline, which inserts the letter at the caret.
+- **Why both paths broke with one root**: `deleteCharacter` was written for plain text leaves, where one-char selection + `cut` produces the right behavior. Code blocks need a code-block-specific path that uses `Range`-and-`Text`-mutation directly (analogous to `openLineBelowInCodeBlock` in `src/content_scripts/navigation/code-block.ts`), bypassing both Notion's clipboard handler and the platform clipboard altogether.
+- **Severity**: **High** in headed (data loss — the user's whole code block is destroyed by a single `x`). High in headless too, but as a different fingerprint. Affected every code-block user.
+- **Follow-up**: `X` (`deleteCharacterBefore` at `vim.ts:376`), `s` (`substituteCharacter` at `vim.ts:397`), `dd` / `D` / motion-delete (`operators/motion-delete.ts:122,189`) all still use `execCommand("cut" | "delete")` and almost certainly share the same data-loss fingerprint inside code blocks. Worth a follow-up PR that ports the same Range-based pattern to those call sites.
 
 ## BUG-046: Cross-spec cumulative flake under `npm test` full-suite run
 

--- a/src/content_scripts/navigation/code-block.ts
+++ b/src/content_scripts/navigation/code-block.ts
@@ -170,6 +170,62 @@ const insertNewlineInCodeBlock = (element: Element): void => {
   );
 };
 
+// Delete a single character at `offset` inside a Notion code block leaf.
+// Replaces the execCommand("cut") path used for plain text leaves, which
+// breaks inside code blocks two ways:
+//   - headed Notion: the `cut` handler treats the code-block contenteditable
+//     as a unit and removes the whole block (data loss);
+//   - headless: execCommand("cut") fails silently and the original `x`
+//     keydown bubbles through, inserting the literal letter at the caret.
+// Vim's `x` doesn't touch the system clipboard anyway, so building a Range
+// over the target character and calling deleteContents() + dispatching an
+// `input` event is both correct and clipboard-free.
+export const deleteCharacterInCodeBlock = (
+  element: Element,
+  offset: number,
+): boolean => {
+  const text = element.textContent || "";
+  if (offset >= text.length) return false;
+  // Vim: `x` does not cross line boundaries. Inside a code block the
+  // visual line break is a literal "\n" inside textContent, so refuse
+  // to delete it — that would join lines, which is not `x` semantics.
+  if (text[offset] === "\n") return false;
+
+  // Capture the (node, offset) pair for both endpoints by walking the
+  // child-node tree via setCursorPosition. A code-block leaf holds many
+  // syntax-highlighted spans, so setEnd(startContainer, startOffset + 1)
+  // is unsafe at token boundaries — the next character may live in a
+  // sibling text node.
+  setCursorPosition(element, offset);
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return false;
+  const startRange = selection.getRangeAt(0);
+  const startContainer = startRange.startContainer;
+  const startOffset = startRange.startOffset;
+
+  setCursorPosition(element, offset + 1);
+  if (selection.rangeCount === 0) return false;
+  const endRange = selection.getRangeAt(0);
+  const endContainer = endRange.startContainer;
+  const endOffset = endRange.startOffset;
+
+  const range = document.createRange();
+  range.setStart(startContainer, startOffset);
+  range.setEnd(endContainer, endOffset);
+  range.deleteContents();
+
+  element.dispatchEvent(
+    new InputEvent("input", {
+      inputType: "deleteContentForward",
+      bubbles: true,
+    }),
+  );
+
+  // After a delete-forward the cursor stays at the same offset.
+  setCursorPosition(element, offset);
+  return true;
+};
+
 // Open line below in code block (o command)
 export const openLineBelowInCodeBlock = () => {
   const { vim_info } = window;

--- a/src/content_scripts/navigation/index.ts
+++ b/src/content_scripts/navigation/index.ts
@@ -27,6 +27,7 @@ export {
   moveCursorForwardsInCodeBlock,
   openLineBelowInCodeBlock,
   openLineAboveInCodeBlock,
+  deleteCharacterInCodeBlock,
 } from "./code-block";
 
 export {

--- a/src/content_scripts/vim.ts
+++ b/src/content_scripts/vim.ts
@@ -85,6 +85,7 @@ import {
   moveCursorForwardsInCodeBlock,
   openLineBelowInCodeBlock,
   openLineAboveInCodeBlock,
+  deleteCharacterInCodeBlock,
   findScrollableContainer,
   scrollAndMoveCursor,
   createJumpToTop,
@@ -355,6 +356,16 @@ const deleteCharacter = () => {
 
   // Don't delete if at end of line
   if (currentCursorPosition >= text.length) return;
+
+  // Code blocks need a clipboard-free path: execCommand("cut") on a
+  // code-block leaf is intercepted by Notion as "cut the whole block"
+  // (data loss in headed) and silently no-ops in headless so the original
+  // `x` keystroke bubbles through and is inserted as the literal letter.
+  if (isInsideCodeBlock(currentElement)) {
+    deleteCharacterInCodeBlock(currentElement, currentCursorPosition);
+    vim_info.desired_column = currentCursorPosition;
+    return;
+  }
 
   // Select the character at cursor position
   setCursorPosition(currentElement, currentCursorPosition);

--- a/test/e2e/code-block-nav.spec.ts
+++ b/test/e2e/code-block-nav.spec.ts
@@ -800,4 +800,106 @@ test.describe("Code block navigation", () => {
     // absolute textContent offset.
     expect(afterVisualCol, "BUG-035: visual column preserved across code-block j after f").toBe(2);
   });
+
+  // =========================================================================
+  // BUG-047: `x` (delete-character) in normal mode inside a code block.
+  // Headed Notion: `cut` handler treats the code-block leaf as a unit and
+  // removes the whole block (data loss). Headless: execCommand("cut") fails
+  // silently and the original keydown bubbles through, inserting the literal
+  // 'x' at the caret. The fix replaces execCommand with a Range-based
+  // mutation + dispatched input event for code-block leaves.
+  // Source: src/content_scripts/vim.ts deleteCharacter
+  // See docs/known-bugs.md, BUG-047 entry.
+  // =========================================================================
+
+  test("BUG-047: x at line-end position in code block does not destroy block or insert 'x'", async ({ extensionPage: page }) => {
+    await goToBlock(page, "Plain text line 1"); // reset
+    await goToBlock(page, "Section 8: Code block");
+
+    // Enter the code block. Code block content:
+    //   "function hello() {\n  console.log('world');\n  return true;\n}"
+    // Line 0: "function hello() {" (18 chars; offset 18 is the '\n').
+    await pressKeys(page, "j"); // enter code block
+    await page.waitForTimeout(150);
+    await pressKeys(page, "0"); // normalize to line 0 col 0, desired_column=0
+    await page.waitForTimeout(80);
+
+    // Walk forward 18 characters to land on offset 18 (= the '\n'
+    // separator between line 0 and line 1). This is the position the
+    // BUG-047 throwaway repro identified — `x` here selects '\n' for
+    // execCommand("cut"), which Notion's cut handler in headed treats as
+    // "cut the whole code block" (data loss), and which in headless fails
+    // silently so the original `x` keystroke bubbles through and is
+    // inserted as the literal letter (length 61 → 62).
+    for (let i = 0; i < 18; i++) {
+      await pressKeys(page, "l");
+      await page.waitForTimeout(25);
+    }
+
+    const before = await getCodeBlockInfo(page);
+    const beforeRealLines = realLineCount(before.text);
+    const beforeTotalLength = before.text.length;
+    console.log("BUG-047 before x: lines =", beforeRealLines, "totalLength =", beforeTotalLength, "offset =", before.offset);
+
+    // x at the '\n' position. Correct semantics in vim: `x` should be a
+    // no-op at end of line (or delete the '\n' to join lines, depending on
+    // the implementation choice). Either way, it must NOT delete the whole
+    // block and must NOT insert the literal letter 'x' into the block.
+    await pressKeys(page, "x");
+    await page.waitForTimeout(200);
+
+    const after = await getCodeBlockInfo(page);
+    const afterRealLines = realLineCount(after.text);
+    const afterTotalLength = after.text.length;
+    console.log("BUG-047 after x: lines =", afterRealLines, "totalLength =", afterTotalLength);
+
+    // Restore so subsequent tests get a clean page even if assertions throw.
+    await pressKeys(page, "u");
+    await page.waitForTimeout(300);
+
+    // BUG-047 (headed): block must not be destroyed.
+    expect(afterRealLines, "BUG-047: x must not destroy the code block").toBeGreaterThan(0);
+    expect(after.text, "BUG-047: code block must still contain the function signature").toContain("function hello");
+
+    // BUG-047 (headless): the keystroke must not be inserted as the literal
+    // 'x'. textContent length must not have grown.
+    expect(afterTotalLength, "BUG-047: x must not insert literal 'x' (length must not grow)").toBeLessThanOrEqual(beforeTotalLength);
+  });
+
+  test("BUG-047: x in middle of code-block line deletes exactly one character", async ({ extensionPage: page }) => {
+    await goToBlock(page, "Plain text line 1"); // reset
+    await goToBlock(page, "Section 8: Code block");
+
+    // Enter line 0 ("function hello() {", 18 chars).
+    await pressKeys(page, "j");
+    await page.waitForTimeout(150);
+    await pressKeys(page, "0");
+    await page.waitForTimeout(80);
+
+    // Walk to col 9 — the 'h' of "hello".
+    for (let i = 0; i < 9; i++) {
+      await pressKeys(page, "l");
+      await page.waitForTimeout(25);
+    }
+
+    const before = await getCodeBlockInfo(page);
+    const beforeFirstLine = before.text.split("\n")[0];
+    console.log("BUG-047 mid pre-x:", JSON.stringify(beforeFirstLine), "offset =", before.offset);
+    expect(beforeFirstLine).toBe("function hello() {");
+
+    await pressKeys(page, "x");
+    await page.waitForTimeout(200);
+
+    const after = await getCodeBlockInfo(page);
+    const afterFirstLine = after.text.split("\n")[0];
+    console.log("BUG-047 mid post-x:", JSON.stringify(afterFirstLine));
+
+    // Restore the deleted character before asserting so subsequent tests
+    // get a clean page even if the assertion throws.
+    await pressKeys(page, "u");
+    await page.waitForTimeout(300);
+
+    // x at the 'h' should remove exactly the 'h', leaving "function ello() {".
+    expect(afterFirstLine, "BUG-047: x in middle of code-block line deletes exactly one character").toBe("function ello() {");
+  });
 });


### PR DESCRIPTION
# Fix `x` inside code blocks: stop destroying blocks / inserting literal 'x'                                                  
                                                                                                                     
## 🔄 Changes                                                                                                                 
- Pressing `x` in normal mode inside a Notion code block was catastrophic in headed Chrome (Notion's `cut` handler treats the
code-block contenteditable as a unit and removed the **entire block** — silent data loss) and wrong in headless               
(`execCommand("cut")` failed silently and the original `x` keystroke bubbled through, inserting the literal letter into the
block).                                                                                                                       
- Added `deleteCharacterInCodeBlock` helper that builds a `Range` over the target character via two `setCursorPosition` calls
(so the start/end pair survives Notion's multi-span PrismJS DOM), calls `range.deleteContents()`, then dispatches             
`InputEvent("input", { inputType: "deleteContentForward" })` so Notion's renderer / undo stack stay consistent — no clipboard
touched (`x` puts the char in vim's unnamed register, not the system clipboard).                                              
- `deleteCharacter` in `vim.ts` now branches on `isInsideCodeBlock(currentElement)` and routes to the helper; plain-text
leaves keep the existing `execCommand("cut")` path unchanged.                                                                 
- Helper refuses to delete a `\n` separator so `x` does not cross visual line boundaries inside a code block, matching vanilla
 vim semantics.                                                                                                               
- Two e2e markers in `code-block-nav.spec.ts`: a failure-before-fix test that lands cursor on the `\n` boundary (covers both
fingerprints) and a positive mid-line case that asserts exactly one character is removed.                                     
                                                                                                                     
## ⚠️  Breaking Changes                                                                                                       
- [ ]                                                                                                                
                                                                                                                              
## 🔍  How to Reproduce                                                                                                       
```bash                             
npm run build                                                                                                                 
npx playwright test --config test/playwright.config.ts -g "BUG-047"                                                  
npx playwright test --config test/playwright.config.ts test/e2e/code-block-nav.spec.ts                                        
```                                                                                                                           
                                                                                                                              
## Notes                                                                                                                      
### TODO:                                                                                                            
- [ ] Port the same Range-based pattern to `X` (`deleteCharacterBefore`), `s` (`substituteCharacter`), and `dd` / `D` /
motion-delete (`operators/motion-delete.ts`) — they still route through `execCommand("cut" | "delete")` and almost certainly  
share the BUG-047 fingerprint inside code blocks.
                                                                                                                              
Note: I escaped the inner ```bash and closing ``` with zero-width-joiner-style markers (the  before the backticks) so the     
outer fence renders cleanly in the chat. Before pasting into GitHub, delete the two zero-width characters in front of those
backticks (or just retype the lines as \``bashand````).                                                                       
