### PR TITLE
fix(visual-line): stop active_line reset on V+j; auto-scroll on motion

### DIFF
--- a/src/content_scripts/core/line-management.ts
+++ b/src/content_scripts/core/line-management.ts
@@ -233,6 +233,22 @@ export const createRefreshLines = (handlers: EventHandlers) => {
 
     let tierOneFired = false;
 
+    // Visual / visual-line mode: skip all selection- and element-identity-
+    // based recovery. The DOM selection in these modes intentionally spans
+    // multiple leaves (anchor on the start leaf, focus on the current
+    // active leaf), so tier-1's "selection-leaf-as-truth" would always
+    // resolve to the start leaf and overwrite the reducer's active_line
+    // every time refreshLines fires — visible as V+j stalling at "2 lines
+    // selected" because each j advance is undone on the next observer
+    // tick. The visual reducers are the source of truth here.
+    if (
+      vim_info.mode === "visual" ||
+      vim_info.mode === "visual-line"
+    ) {
+      updateInfoContainer();
+      return;
+    }
+
     // Tier 0: undo-scoped code-block anchor. Only active inside the post-
     // undo window opened by undo() in vim.ts.
     const undoSettleUntil =
@@ -338,6 +354,20 @@ export const createSetLines = (
     // the status bar, block-cursor overlay, and dataset bridge agree with
     // vim_info.
     const reconcileFromSelection = (): boolean => {
+      // Visual / visual-line mode reducers manage `active_line` explicitly
+      // and intentionally extend the DOM Selection across multiple leaves.
+      // Reconciling from the selection's anchor here would reset
+      // active_line back to the first leaf of the selection on every
+      // selectionchange — observable as V+j stalling at "2 lines selected"
+      // because each j advance is immediately undone (anchor stays on the
+      // start leaf while focus moves down). V+k coincidentally works
+      // because there the anchor is the new active line.
+      if (
+        vim_info.mode === "visual" ||
+        vim_info.mode === "visual-line"
+      ) {
+        return false;
+      }
       const sel = window.getSelection();
       const anchor = sel?.anchorNode ?? null;
       if (!anchor) return false;

--- a/src/content_scripts/vim.ts
+++ b/src/content_scripts/vim.ts
@@ -1072,6 +1072,7 @@ const visualLineMoveCursorDown = () => {
   }
 
   updateVisualLineSelection();
+  scrollActiveLineIntoView();
   updateInfoContainer();
 };
 
@@ -1144,7 +1145,24 @@ const visualLineMoveCursorUp = () => {
   }
 
   updateVisualLineSelection();
+  scrollActiveLineIntoView();
   updateInfoContainer();
+};
+
+// Scroll the active line into view if it has fallen outside the viewport.
+// Visual-line mode does not call `setActiveLine` (which goes through
+// Notion's click handler and gets free auto-scroll); the selection-only
+// path leaves the viewport behind when the new active leaf is offscreen,
+// so we explicitly nudge it. `block: "nearest"` keeps an already-visible
+// line where it is and only scrolls when needed; `behavior: "instant"`
+// avoids smooth-scroll lag during j/k repeats.
+const scrollActiveLineIntoView = (): void => {
+  const { vim_info } = window;
+  const el = vim_info.lines[vim_info.active_line]?.element as
+    | HTMLElement
+    | undefined;
+  if (!el || typeof el.scrollIntoView !== "function") return;
+  el.scrollIntoView({ block: "nearest", behavior: "instant" as ScrollBehavior });
 };
 
 const visualLineJumpToPreviousParagraph = (): void => {

--- a/test/e2e/visual-line.spec.ts
+++ b/test/e2e/visual-line.spec.ts
@@ -71,4 +71,49 @@ test.describe.serial("Visual-line mode — pending operator state", () => {
     expect(state.activeLine, "BUG-014: active_line must NOT be 1 after V g Esc g").not.toBe(1);
     expect(state.mode, "should be back in normal mode after Escape").toBe("normal");
   });
+
+  // =========================================================================
+  // V + j repeated must extend the selection one line per press, not stall.
+  // =========================================================================
+  // Repro: in visual-line mode, every `j` advances `active_line` by one and
+  // calls `updateVisualLineSelection`, which sets a multi-leaf DOM Range
+  // anchored at the start leaf and focused at the new active leaf. The
+  // resulting `selectionchange` used to fire `reconcileFromSelection`, which
+  // read the selection's anchorNode (still the start leaf) and reset
+  // `active_line` back to it — so each `j` was immediately undone and the
+  // selection was stuck at "start..start+1". `V + k` worked by accident
+  // because there the anchor IS the new active leaf.
+  test("V + j repeated extends selection by one line each press", async ({ extensionPage: page }) => {
+    await goToBlock(page, "Plain text line 1");
+    const startState = await getVimState(page);
+
+    await pressKeys(page, "V");
+    await waitForMode(page, "visual-line");
+    await page.waitForTimeout(50);
+
+    for (let i = 0; i < 4; i++) {
+      await pressKeys(page, "j");
+      await page.waitForTimeout(80);
+    }
+
+    const after = await getVimState(page);
+    console.log(
+      "V+j x4: startActiveLine =",
+      startState.activeLine,
+      "endActiveLine =",
+      after.activeLine,
+    );
+
+    // Four `j` presses must move the active line down by 4. With the
+    // reconcile bug, active_line would stall at startActiveLine + 1.
+    expect(
+      after.activeLine - startState.activeLine,
+      "V+j×4 must advance active_line by 4, not get stuck at +1",
+    ).toBe(4);
+    expect(after.mode).toBe("visual-line");
+
+    // Restore for any followup tests.
+    await page.keyboard.press("Escape");
+    await waitForMode(page, "normal");
+  });
 });


### PR DESCRIPTION
# Fix V+j stalling and missing scroll in visual-line mode                                                                                       
                                                                                                                                      
## 🔄 Changes                                                                                                                                   
- Holding j (or pressing it repeatedly) in visual-line mode now keeps extending the selection one line at a time instead of stalling at "2 lines
 selected". V+k was already working by accident; both directions now behave consistently.                                                       
- The viewport now scrolls along when the active line moves off-screen during V+j / V+k. Previously the selection extended past the viewport
silently.                                                                                                                                       
- Root cause for the stall: `refreshLines` was firing during selection updates and using its tier-1 "selection-leaf-as-truth" recovery to set
`active_line` to the multi-leaf selection's anchor (the start leaf), undoing each motion. Tier-1 and `reconcileFromSelection` now no-op while in
 visual / visual-line mode, where the reducers are the source of truth.                                                   
                                                                                                                                                
## ⚠️  Breaking Changes                                                                                                   
- [ ]                               
                                                                                                                                                 
## 🔍  How to Reproduce
```bash
npm run build                                                                                                                                   
npx playwright test --config test/playwright.config.ts test/e2e/visual-line.spec.ts test/e2e/mode-transitions.spec.ts
test/e2e/navigation.spec.ts                                                                                                                     
# Manual: open Notion, click into a line, press Shift+V, then hold j —                                                    
# selection must extend one line per repeat, and the page must scroll                                                                           
# down once the active line falls below the viewport. Same with Shift+V                                                                         
# then hold k.                                                                                                                                  
