### PR TITLE
fix: b wrap previous block

### DIFF
--- a/docs/e2e-test-catalog.md
+++ b/docs/e2e-test-catalog.md
@@ -567,8 +567,8 @@ Block types not already in operators-block-types.spec.ts.
 
 | # | Test | Status | Notes |
 |---|------|--------|-------|
-| 20 | BUG-036: h in code block preserves visual column for subsequent j/k | Fail (expected) | h/l set desired_column to absolute textContent offset |
-| 21 | BUG-035: f in code block preserves visual column for subsequent j | Fail (expected) | f/F/t/T set desired_column to absolute textContent offset |
+| 20 | BUG-036: h in code block preserves visual column for subsequent j/k | Pass | Code-block h/l now write `desired_column` via `codeBlockVisualColumn` |
+| 21 | BUG-035: f in code block preserves visual column for subsequent j | Pass | Code-block f/F/t/T now write `desired_column` via `visualColumn` helper |
 
 ### x in code block (BUG-047)
 

--- a/docs/known-bugs.md
+++ b/docs/known-bugs.md
@@ -191,24 +191,22 @@ violation naming the exact shortcut that broke (`## conversion + Esc`,
 ## BUG-035: `f` / `F` / `t` / `T` in multi-line code block set `desired_column` to absolute textContent offset
 
 - **Detected**: 2026-05-03
+- **Status**: **RESOLVED.** All four character-find functions in `src/content_scripts/navigation/char-find.ts` now compute `desired_column` via a `visualColumn(text, offset)` helper that measures the column from the most recent `\n`, so the value is the per-line column rather than the absolute textContent offset. `code-block-nav.spec.ts:755` (BUG-035) passes.
 - **Source**: Latent bug found by code reading (see `docs/test-overhaul/bug-investigation.md`).
 - **Test**: `code-block-nav.spec.ts` → "BUG-035: f in code block preserves visual column for subsequent j"
-- **Reproduction**: In a multi-line code block, position cursor on a non-first line, press `f{char}` (or `F` / `t` / `T`) to find a character on that line. Then press `j` to move down. The cursor lands at `min(absolute_offset, next_line_length)` instead of the visual column from the search target — typically end-of-line on shorter lines.
-- **Root cause**: `src/content_scripts/navigation/char-find.ts:21-22, :39-40, :58-59, :77-78`. All four character-find functions set `vim_info.desired_column = foundIndex` (or `foundIndex - 1` / `+ 1`) where `foundIndex` is the position from `text.indexOf(char, currentPos)` against the FULL code-block textContent (which includes `\n`). For non-code-blocks this is fine (single-line text), but for code blocks the absolute offset is not a visual column. Subsequent `j` / `k` then misuse this number as the target column on the next line.
-- **Expected**: After `f{c}` lands the cursor at visual column N of a code-block line, `j` moves to visual column min(N, next_line_length).
-- **Actual**: Cursor lands at min(absolute_offset, next_line_length) → typically end-of-line.
-- **Severity**: High — corrupts column-memory after any character-search inside a code block.
+- **Reproduction (pre-fix)**: In a multi-line code block, position cursor on a non-first line, press `f{char}` (or `F` / `t` / `T`) to find a character on that line. Then press `j` to move down. The cursor landed at `min(absolute_offset, next_line_length)` instead of the visual column from the search target — typically end-of-line on shorter lines.
+- **Root cause**: All four character-find functions set `vim_info.desired_column = foundIndex` (or `foundIndex - 1` / `+ 1`) where `foundIndex` is the position from `text.indexOf(char, currentPos)` against the FULL code-block textContent (which includes `\n`). For non-code-blocks this was fine (single-line text), but for code blocks the absolute offset is not a visual column. Subsequent `j` / `k` then misused this number as the target column on the next line.
+- **Severity**: Was High — corrupted column-memory after any character-search inside a code block.
 
 ## BUG-036: `h` / `l` in multi-line code block set `desired_column` to absolute textContent offset
 
 - **Detected**: 2026-05-03
+- **Status**: **RESOLVED.** `moveCursorBackwardsInCodeBlock` and `moveCursorForwardsInCodeBlock` in `src/content_scripts/navigation/code-block.ts` now compute `desired_column` via `codeBlockVisualColumn(text, newPos)`, which measures the column from the start of the current logical line. `code-block-nav.spec.ts:678` (BUG-036) passes.
 - **Source**: Latent bug found by code reading (see `docs/test-overhaul/bug-investigation.md`).
 - **Test**: `code-block-nav.spec.ts` → "BUG-036: h in code block preserves visual column for subsequent j/k"
-- **Reproduction**: In a multi-line code block, position cursor on a non-first line at column N (e.g. `j j l l l l l` → line 2 col 5). Press `h` (or `l`) to move horizontally. Press `j` — cursor lands at end of next line instead of visual column N±1.
-- **Root cause**: `src/content_scripts/navigation/code-block.ts:87` (`moveCursorBackwardsInCodeBlock`) and `:106` (`moveCursorForwardsInCodeBlock`). Both do `vim_info.desired_column = newPos` where `newPos = currentPos ± 1` — an absolute offset within the code-block textContent (containing `\n`). The exit-block `j` / `k` paths and `moveCursorDownInCodeBlock` then use `desired_column` as a per-line column, mis-clamping to `min(absolute_offset, line_length)`.
-- **Expected**: `h` / `l` in a code block update `desired_column` to the visual column on the current line.
-- **Actual**: `desired_column` polluted with absolute offset; vertical motion column-memory broken.
-- **Severity**: High — every `h` / `l` keystroke inside a code block corrupts subsequent `j` / `k` column landing.
+- **Reproduction (pre-fix)**: In a multi-line code block, position cursor on a non-first line at column N (e.g. `j j l l l l l` → line 2 col 5). Press `h` (or `l`) to move horizontally. Press `j` — cursor landed at end of next line instead of visual column N±1.
+- **Root cause**: Both code-block horizontal-move functions did `vim_info.desired_column = newPos` where `newPos = currentPos ± 1` — an absolute offset within the code-block textContent (containing `\n`). The exit-block `j` / `k` paths and `moveCursorDownInCodeBlock` then used `desired_column` as a per-line column, mis-clamping to `min(absolute_offset, line_length)`.
+- **Severity**: Was High — every `h` / `l` keystroke inside a code block corrupted subsequent `j` / `k` column landing.
 
 ## BUG-029: `j` exiting code block bumps `active_line` but leaves DOM cursor inside
 

--- a/src/content_scripts/core/index.ts
+++ b/src/content_scripts/core/index.ts
@@ -11,6 +11,7 @@ export {
 
 export {
   setActiveLine,
+  isWrapperLine,
   createRefreshLines,
   createSetLines,
 } from "./line-management";

--- a/src/content_scripts/core/line-management.ts
+++ b/src/content_scripts/core/line-management.ts
@@ -36,7 +36,7 @@ type EventHandlers = {
  * transiently-stranded H1's. So we keep wrappers in `lines` but skip
  * them at the navigation boundary here.
  */
-const isWrapperLine = (idx: number): boolean => {
+export const isWrapperLine = (idx: number): boolean => {
   const el = window.vim_info.lines[idx]?.element;
   if (!el) return false;
   return window.vim_info.lines.some(

--- a/src/content_scripts/navigation/word.ts
+++ b/src/content_scripts/navigation/word.ts
@@ -3,6 +3,7 @@
  */
 
 import { getCursorIndexInElement, setCursorPosition } from "../cursor";
+import { isWrapperLine } from "../core";
 
 export const jumpToNextWord = () => {
   const { vim_info } = window;
@@ -41,9 +42,30 @@ export const jumpToPreviousWord = () => {
   const currentCursorPosition = getCursorIndexInElement(currentElement);
   const text = currentElement.textContent || "";
 
-  // Vim semantics in Notion (block = line): b at col 0 is a no-op (no wrap to
-  // previous block). Matches the h no-wrap policy.
-  if (currentCursorPosition === 0) return;
+  // Vim: b at col 0 wraps to the start of the last word on the previous
+  // line (block, in Notion). Mirrors `w`'s wrap-forward at end-of-line —
+  // without this, `b` is asymmetric with `w` and gets stuck at the top
+  // of every block. The earlier "match h's no-wrap policy" comment was
+  // wrong in spirit: `b` is a word motion, not a column motion.
+  if (currentCursorPosition === 0) {
+    // Walk back past wrapper lines (the page-title contenteditable wraps
+    // the H1 leaf and surfaces in lines[] for keystroke reasons; it has
+    // no navigable text).
+    let prevIdx = vim_info.active_line - 1;
+    while (prevIdx >= 0 && isWrapperLine(prevIdx)) prevIdx--;
+    if (prevIdx < 0) return;
+    vim_info.active_line = prevIdx;
+    const prevElement = vim_info.lines[prevIdx].element;
+    const prevText = prevElement.textContent || "";
+    // Find the start of the last word: walk back over trailing non-word
+    // characters, then back over the word itself.
+    let p = prevText.length;
+    while (p > 0 && !/\w/.test(prevText[p - 1])) p--;
+    while (p > 0 && /\w/.test(prevText[p - 1])) p--;
+    setCursorPosition(prevElement, p);
+    vim_info.desired_column = p;
+    return;
+  }
 
   let pos = currentCursorPosition - 1;
 

--- a/test/e2e/navigation.spec.ts
+++ b/test/e2e/navigation.spec.ts
@@ -282,15 +282,42 @@ test.describe.serial("Navigation", () => {
     expect((await getCursorPosition(page)).col).toBe(4);
   });
 
-  // BUG-004 fixed (jumpToPreviousWord no-ops at col 0).
-  test("b at column 0 stays at 0", async ({ extensionPage: page }) => {
-    await goToBlock(page, "The quick brown fox");
+  // `b` at col 0 wraps to the start of the last word on the previous
+  // block, mirroring `w`'s wrap-forward at end-of-line. Without the
+  // wrap, `b` is asymmetric with `w` and gets stuck at the top of every
+  // block.
+  test("b at column 0 wraps to previous block's last word", async ({ extensionPage: page }) => {
+    await goToBlock(page, "Plain text line 2");
     await pressKeys(page, "0");
     await page.waitForTimeout(100);
 
     await pressKeys(page, "b");
+    await page.waitForTimeout(150);
+
+    // The previous block is "Plain text line 1" — `b` from col 0 of
+    // line 2 should land on the start of "1" (the last word). Assert
+    // active block changed AND we're not at col 0 of the original block.
+    const text = await getActualCursorBlockText(page);
+    expect(text, "b at col 0 should move to the previous block").toContain(
+      "Plain text line 1",
+    );
+  });
+
+  test("b at column 0 of first block stays put", async ({ extensionPage: page }) => {
+    // The first navigable block in the test page (vim_info.lines[0] is the
+    // page title wrapper which b cannot reach via word motion). `b` at
+    // col 0 of the topmost block must be a no-op, not crash or wrap.
+    await pressKeys(page, "g", "g");
+    await page.waitForTimeout(150);
+    const beforeText = await getActualCursorBlockText(page);
+    await pressKeys(page, "0");
+    await page.waitForTimeout(80);
+
+    await pressKeys(page, "b");
     await page.waitForTimeout(100);
 
+    const afterText = await getActualCursorBlockText(page);
+    expect(afterText, "b at top-of-doc must not wrap into a non-existent block").toBe(beforeText);
     expect((await getCursorPosition(page)).col).toBe(0);
   });
 


### PR DESCRIPTION
# Make b wrap to previous block; mark BUG-035 / BUG-036 resolved                                                                                
                                                                                                                                              
## 🔄 Changes                                                                                                                                   
- `b` at column 0 now wraps to the start of the last word on the previous block, mirroring `w`'s wrap-forward at end-of-line. Previously `b` was
 a no-op at col 0, leaving the cursor stuck at the top of every block — asymmetric with `w` and surprising for vim users. Top-of-document still 
no-ops, and the page-title wrapper is skipped.                                                                                                
- BUG-035 (`f` / `F` / `t` / `T` desired_column corruption in code blocks) and BUG-036 (`h` / `l` desired_column corruption in code blocks)     
marked RESOLVED in `docs/known-bugs.md` and the test catalog. The fixes already shipped — both reducers compute `desired_column` via            
`visualColumn` / `codeBlockVisualColumn` helpers and the test markers pass on main — only the docs were stale.
                                                                                                                                                
## ⚠️  Breaking Changes                                                                                                                       
- [ ] `b` at column 0 of a non-top block now moves the cursor to the previous block. Code that relied on `b` being a no-op at column 0 (none
in-tree) would observe a behaviour change.                                                                                                      
 
## 🔍  How to Reproduce                                                                                                                         
```bash                                                                                                                                       
npm run build                                                                                                                                   
npx playwright test --config test/playwright.config.ts test/e2e/navigation.spec.ts                                                            
# Manual: open Notion, click into the second block, press 0 then b — cursor                                                                     
# should jump to the start of the last word on the block above. Press gg                                                                        
# then 0 then b at the very top — cursor stays put.                                                                                             
