### PR TITLE
Support notion.com domain and set new default theme color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Vimtion will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.6] - 2026-05-30
+
+### Fixed
+- **Notion `notion.com` domain migration**: Notion moved its app from `notion.so` to `notion.com` (`app.notion.com`). The content script now also matches `*://*.notion.com/*`, so Vimtion loads on the new domain instead of silently not running. The Vimium-exclusion URL hint in the update notification now points at `notion.com`.
+
+### Changed
+- **Default theme color**: new installs now default to red (`#ff4458`) for the status bar, block cursor, and visual-mode highlight (previously blue `#667eea`). Existing installs are pinned to the old blue on update, and anyone who customized their colors keeps their own choice — so nobody's current colors change.
+
 ## [1.5.5] - 2026-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimtion",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A Chrome extension that brings Vim keybindings to Notion, updated for modern Chrome compatibility.",
   "scripts": {
     "build": "rm -rf dist && parcel build src/background.ts --dist-dir dist && parcel build src/content_scripts/{vim.ts,vim.css,update-notification.ts,update-notification.css} --dist-dir dist/content_scripts && parcel build src/options/{options.html,options.ts,options.css} --dist-dir dist/options --public-url ./ && cp src/manifest.json dist/ && cp -r src/icons dist/",

--- a/src/background.ts
+++ b/src/background.ts
@@ -19,5 +19,23 @@ chrome.runtime.onInstalled.addListener((details) => {
       vimtion_version: newVersion,
       vimtion_previous_version: oldVersion,
     });
+
+    // The default theme colors changed from blue (#667eea) to red (#ff4458).
+    // Pin existing installs to the old blue default so only fresh installs get
+    // the new color. Only fills in colors the user never explicitly set, so
+    // anyone who already customized keeps their own choice.
+    const LEGACY_DEFAULT_COLOR = "#667eea";
+    const colorKeys = ["statusBarColor", "cursorColor", "visualHighlightColor"];
+    chrome.storage.sync.get(colorKeys, (stored) => {
+      const patch: Record<string, string> = {};
+      colorKeys.forEach((key) => {
+        if (stored[key] === undefined) {
+          patch[key] = LEGACY_DEFAULT_COLOR;
+        }
+      });
+      if (Object.keys(patch).length > 0) {
+        chrome.storage.sync.set(patch);
+      }
+    });
   }
 });

--- a/src/content_scripts/types.ts
+++ b/src/content_scripts/types.ts
@@ -23,10 +23,10 @@ export interface VimtionSettings {
 export const DEFAULT_SETTINGS: VimtionSettings = {
   showStatusBar: true,
   statusBarPosition: "bottom-right",
-  statusBarColor: "#667eea",
+  statusBarColor: "#ff4458",
   cursorBlink: true,
-  cursorColor: "#667eea",
-  visualHighlightColor: "#667eea",
+  cursorColor: "#ff4458",
+  visualHighlightColor: "#ff4458",
   showUpdateNotifications: true,
   linkHintsEnabled: true,
   hintCharacters: "asdfghjklqwertyuiopzxcvbnm",

--- a/src/content_scripts/update-notification.ts
+++ b/src/content_scripts/update-notification.ts
@@ -141,7 +141,7 @@ function showVimiumWarning() {
   overlay?.addEventListener("click", dismissWithOverlay);
 
   copyBtn?.addEventListener("click", async () => {
-    const url = "https://www.notion.so/*";
+    const url = "https://www.notion.com/*";
     try {
       await navigator.clipboard.writeText(url);
       // Show visual feedback
@@ -179,7 +179,7 @@ function createVimiumWarningElement(): HTMLElement {
         <strong>Excluded URLs and keys</strong> in Vimium settings to avoid key binding conflicts:
       </div>
       <div class="vimtion-notification-url-container">
-        <code class="vimtion-notification-url">https://www.notion.so/*</code>
+        <code class="vimtion-notification-url">https://www.notion.com/*</code>
         <button class="vimtion-notification-copy" aria-label="Copy URL" title="Copy to clipboard">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vimtion: Vim for Notion",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A Chrome extension that brings Vim keybindings to Notion",
   "author": "Tatsuya Kamijo",
   "icons": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,7 @@
   "options_page": "options/options.html",
   "content_scripts": [
     {
-      "matches": ["*://*.notion.so/*"],
+      "matches": ["*://*.notion.so/*", "*://*.notion.com/*"],
       "js": [
         "content_scripts/vim.js",
         "content_scripts/update-notification.js"

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -55,8 +55,8 @@
         <div class="setting-item">
           <label for="statusBarColor">Status Bar Theme Color</label>
           <div class="color-picker-wrapper">
-            <input type="color" id="statusBarColor" value="#667eea">
-            <input type="text" id="statusBarColorText" value="#667eea" class="color-text-input">
+            <input type="color" id="statusBarColor" value="#ff4458">
+            <input type="text" id="statusBarColorText" value="#ff4458" class="color-text-input">
           </div>
           <p class="setting-description">Theme color for status bar and settings page</p>
         </div>
@@ -64,8 +64,8 @@
         <div class="setting-item">
           <label for="cursorColor">Cursor Color</label>
           <div class="color-picker-wrapper">
-            <input type="color" id="cursorColor" value="#667eea">
-            <input type="text" id="cursorColorText" value="#667eea" class="color-text-input">
+            <input type="color" id="cursorColor" value="#ff4458">
+            <input type="text" id="cursorColorText" value="#ff4458" class="color-text-input">
           </div>
           <p class="setting-description">Color of the block cursor in normal mode</p>
         </div>
@@ -73,8 +73,8 @@
         <div class="setting-item">
           <label for="visualHighlightColor">Visual Mode Highlight</label>
           <div class="color-picker-wrapper">
-            <input type="color" id="visualHighlightColor" value="#667eea">
-            <input type="text" id="visualHighlightColorText" value="#667eea" class="color-text-input">
+            <input type="color" id="visualHighlightColor" value="#ff4458">
+            <input type="text" id="visualHighlightColorText" value="#ff4458" class="color-text-input">
           </div>
           <p class="setting-description">Background color for visual mode selection</p>
         </div>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -19,10 +19,10 @@ interface VimtionSettings {
 const DEFAULT_SETTINGS: VimtionSettings = {
   showStatusBar: true,
   statusBarPosition: "bottom-right",
-  statusBarColor: "#667eea",
+  statusBarColor: "#ff4458",
   cursorBlink: true,
-  cursorColor: "#667eea",
-  visualHighlightColor: "#667eea",
+  cursorColor: "#ff4458",
+  visualHighlightColor: "#ff4458",
   showUpdateNotifications: true,
   linkHintsEnabled: true,
   hintCharacters: "asdfghjklqwertyuiopzxcvbnm",


### PR DESCRIPTION
# Support notion.com domain and set new default theme color
                                                                            
## 🔄 Changes
- Vimtion now loads on Notion's migrated `notion.com` / `app.notion.com`
domain. Notion moved its app off `notion.so`, and the content script's
`matches` was limited to `*://*.notion.so/*`, so the extension silently
stopped injecting — this adds `*://*.notion.com/*`.
- New installs now default to red (`#ff4458`) for the status bar, block
cursor, and visual-mode highlight (previously blue `#667eea`).
- Existing users are unaffected by the color change: a
`chrome.runtime.onInstalled` "update" migration pins installs to the old
blue when those keys are unset, and anyone who already customized keeps
their stored colors.
- Updated the Vimium-exclusion URL hint in the update notification to point
at `notion.com`.
- Bumped version to 1.5.6 and added the CHANGELOG entry, which triggers the
automated release + Chrome Web Store publish on merge to main.
                                                                            
## ⚠️  Breaking Changes
- [ ] None — the color migration guarantees existing installs keep their
current colors.
                                                                            
## 🔍  How to Reproduce
```bash
npm run build
# Load dist/ as an unpacked extension at chrome://extensions
# 1. Open app.notion.com — the status bar should appear and h/j/k/l should work (regression check)
# 2. On a fresh profile, cursor/status-bar/visual highlight default to red
(#ff4458)
# 3. On an existing profile (or after "update"), colors stay blue/your
custom choice
```
                                                                            
## Notes
### TODO:
- [ ] Visual-line `Esc` highlight residue is still under investigation;
suspected to be Vimium key interception on the previously-unexcluded
`notion.com` domain rather than a Vimtion bug. Not blocking this release.
