### PR TITLE
feat(visual-line): add Shift+J/K to move selected blocks up/down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Vimtion will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-05-30
+
+### Added
+- **Move blocks in visual-line mode**: in `Shift+V` selection, `Shift+J` moves the selected block(s) down one position and `Shift+K` moves them up, driving Notion's native block-move shortcut. The selection stays active so you can keep nudging, and it stops at the document edges.
+
 ## [1.6.0] - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ The following Vim features are not implemented:
 - [ ] **Help page** (`?`): Display Vimium-style help overlay showing all keybindings
 - [ ] **Visual block mode** (`Ctrl+v`): Rectangular/column selection
 - [ ] **Code block CLI mode**: Specify code block language from command
-- [ ] **Line movement**: Alt/Option key for moving lines up/down
+- [x] **Line movement**: `Shift+J` / `Shift+K` in visual-line mode to move selected blocks down/up
 - [ ] **Visual-line performance**: Optimize `Shift+V` for better performance, currently a bit slow
 - [ ] **Table navigation**: Vim-like navigation within Notion tables (similar to page link handling)
 - [ ] **Repeat command** (`.`): Repeat the last command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimtion",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A Chrome extension that brings Vim keybindings to Notion, updated for modern Chrome compatibility.",
   "scripts": {
     "build": "rm -rf dist && parcel build src/background.ts --dist-dir dist && parcel build src/content_scripts/{vim.ts,vim.css,update-notification.ts,update-notification.css} --dist-dir dist/content_scripts && parcel build src/options/{options.html,options.ts,options.css} --dist-dir dist/options --public-url ./ && cp src/manifest.json dist/ && cp -r src/icons dist/",

--- a/src/content_scripts/vim.ts
+++ b/src/content_scripts/vim.ts
@@ -1125,6 +1125,14 @@ const visualLineReducer = (e: KeyboardEvent): boolean => {
     case "y":
       yankVisualLineSelection();
       return true;
+    case "J":
+      // Move the selected block(s) down one position, keeping them selected.
+      moveVisualLineSelection("down");
+      return true;
+    case "K":
+      // Move the selected block(s) up one position, keeping them selected.
+      moveVisualLineSelection("up");
+      return true;
     default:
       return true; // Block other keys in visual-line mode
   }
@@ -1458,6 +1466,78 @@ const changeCodeBlockLines = (firstLine: number, lastLine: number) => {
       element.focus();
       setCursorPosition(element, 0);
     }
+    updateInfoContainer();
+  }, 50);
+};
+
+// Resolve a cached block_id back to its current index after Notion re-renders.
+// Falls back to a clamped index when the block_id is missing or not found.
+const findLineByBlockId = (
+  blockId: string | null,
+  fallback: number,
+): number => {
+  const { vim_info } = window;
+  if (blockId) {
+    const idx = vim_info.lines.findIndex((line) => line.block_id === blockId);
+    if (idx !== -1) return idx;
+  }
+  return Math.max(0, Math.min(fallback, vim_info.lines.length - 1));
+};
+
+// Move the visual-line selection up/down one block by driving Notion's own
+// "move block" shortcut (Cmd/Ctrl+Shift+Arrow), then re-anchoring the selection
+// onto the same blocks at their new positions. The selection stays active so
+// the user can keep nudging with repeated Shift+J / Shift+K (Vim vim-move style).
+const moveVisualLineSelection = (direction: "up" | "down") => {
+  const { vim_info } = window;
+  const startLine = vim_info.visual_start_line;
+  const endLine = vim_info.active_line;
+  const [firstLine, lastLine] =
+    startLine <= endLine ? [startLine, endLine] : [endLine, startLine];
+
+  // Can't move past the document edges.
+  if (direction === "up" && firstLine <= 0) return;
+  if (direction === "down" && lastLine >= vim_info.lines.length - 1) return;
+
+  // Remember the moving blocks so we can re-find them after the re-render.
+  const firstBlockId = vim_info.lines[firstLine].block_id;
+  const lastBlockId = vim_info.lines[lastLine].block_id;
+  const downward = startLine <= endLine; // selection grows downward (active at bottom)
+
+  // Trigger Notion's native block move on the current multi-block selection.
+  const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  const arrowKey = direction === "down" ? "ArrowDown" : "ArrowUp";
+  const moveEvent = new KeyboardEvent("keydown", {
+    key: arrowKey,
+    code: arrowKey,
+    keyCode: direction === "down" ? 40 : 38,
+    which: direction === "down" ? 40 : 38,
+    metaKey: isMac,
+    ctrlKey: !isMac,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  (document.activeElement ?? document).dispatchEvent(moveEvent);
+
+  // After Notion reorders and re-renders the blocks, re-scan the line cache and
+  // pin the selection back onto the same blocks (now shifted by one slot).
+  const delta = direction === "down" ? 1 : -1;
+  setTimeout(() => {
+    refreshLines();
+    const newFirst = findLineByBlockId(firstBlockId, firstLine + delta);
+    const newLast = findLineByBlockId(lastBlockId, lastLine + delta);
+
+    if (downward) {
+      vim_info.visual_start_line = newFirst;
+      vim_info.active_line = newLast;
+    } else {
+      vim_info.visual_start_line = newLast;
+      vim_info.active_line = newFirst;
+    }
+
+    updateVisualLineSelection();
+    scrollActiveLineIntoView();
     updateInfoContainer();
   }, 50);
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vimtion: Vim for Notion",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A Chrome extension that brings Vim keybindings to Notion",
   "author": "Tatsuya Kamijo",
   "icons": {


### PR DESCRIPTION
# Add visual-line block movement (Shift+J / Shift+K)
                                                                             
## 🔄 Changes
- In `Shift+V` (visual-line) mode, `Shift+J` moves the selected block(s)
down one position and `Shift+K` moves them up, so you can reorder blocks
without the mouse.
- The selection stays active after a move, so repeated `Shift+J` / `Shift+K`
keeps nudging the same blocks; movement stops cleanly at the document's
first/last block.
- Implemented by dispatching Notion's own block-move shortcut
(Cmd/Ctrl+Shift+Arrow) against the current multi-block selection, then
re-anchoring the selection onto the same blocks by their `data-block-id`
after Notion re-renders.
- Bumps version to 1.7.0 and ticks the README "Line movement" roadmap item;
merging to main triggers the automated release and Chrome Web Store publish.

## ⚠️  Breaking Changes
- [ ] None. `Shift+J` / `Shift+K` were previously inert (swallowed by the
visual-line default case); no existing binding changes.

## 🔍  How to Reproduce
```bash
npm run build
# Load dist/ as an unpacked extension at chrome://extensions, reload it,
# then on app.notion.com:
#   - cursor on a block, Shift+V, then Shift+J / Shift+K -> block moves down / up
#   - Shift+V then j to span several blocks, Shift+J / Shift+K -> whole range moves, stays selected
#   - at the top/bottom block, Shift+K / Shift+J is a no-op (no crash)
```

## Notes
### TODO:
- [ ] No e2e spec: the Playwright harness still authenticates against
`notion.so` and times out on the `notion.com` domain. Add a `Shift+J/K` spec
